### PR TITLE
Minor fixes

### DIFF
--- a/lib/systems.json
+++ b/lib/systems.json
@@ -1919,7 +1919,7 @@
       "effect_type": "AI",
       "detail": "Your mech gains the AI tag and Unleash SCYLLA.",
       "abilities": [{
-        "name": "Hurl Into the Duat",
+        "name": "Unleash SCYLLA",
         "effect_type": "Basic",
         "activation": "Quick",
         "detail": "Until the start of your next turn, you gain two special reactions that allow you to Skirmish in response to one of the following triggers (chosen when you take this action):<li>A hostile character makes an attack against you or an allied character within range 3 of you.<li>A hostile character attempts to attack or interact with an object chosen when you take Unleash Scylla and within line of sight. Characters are aware of the object chosen.<br>These reactions deal half damage, heat or burn on hit and must target the character that triggered them.",
@@ -1929,7 +1929,7 @@
         }]
       }]
     },
-    "description": "The first specifications for the Gorgon pattern group hid a secret: SCYLLA, a dormant NHP unknown to Union until its first manifestation in 4852u, when it woke after Union Science Bureau officers ran a test-fax Gorgon through a Balwinder-Bola�o test.<br>SCYLLA proved challenging: USB ontologicians were unable to pin down a stable subjectivity, and SCYLLA reached cascade threshold within minutes of manifestation. To prevent further metastatic cascade, site security engaged SCYLLA's prime unit, defabricating it with a steady bombardment of kinetic and energy weapons.<br><span class='ra-quiet'>[there, a little history, a little background. a little knowledge of where this little one came from. treat it with kindness, and it will love you as a loyal dog does its master.]</span>",
+    "description": "The first specifications for the Gorgon pattern group hid a secret: SCYLLA, a dormant NHP unknown to Union until its first manifestation in 4852u, when it woke after Union Science Bureau officers ran a test-fax Gorgon through a Balwinder-Bolaño test.<br>SCYLLA proved challenging: USB ontologicians were unable to pin down a stable subjectivity, and SCYLLA reached cascade threshold within minutes of manifestation. To prevent further metastatic cascade, site security engaged SCYLLA's prime unit, defabricating it with a steady bombardment of kinetic and energy weapons.<br><span class='ra-quiet'>[there, a little history, a little background. a little knowledge of where this little one came from. treat it with kindness, and it will love you as a loyal dog does its master.]</span>",
     "data_type": "system",
     "aptitude": {}
   },

--- a/lib/weapons.json
+++ b/lib/weapons.json
@@ -714,6 +714,7 @@
     "license": "DRAKE",
     "license_level": 3,
     "effect": {
+      "effect_type": "Offensive",
       "detail": "Unlike other Superheavy weapons, the Leviathan can be used with Skirmish. You can spin up this weapon’s barrels as a quick action.",
       "abilities": [{
         "effect_type": "Profile",
@@ -2523,6 +2524,7 @@
     "mount": "Ship-class",
     "type": "Spool Weapon",
     "effect": {
+      "effect_type": "Offensive",
       "detail": "The Apocalypse Rail must be charged before it can be fired, using the Charge Rail CORE Power.<br>This weapon has different profiles determined by the current value of the APOCALYPSE DIE when you fire it. Each profile replaces the one proceeding it. The Apocalypse Rail cannot be fired at targets within range 5.",
       "abilities": [{
           "effect_type": "Profile",

--- a/lib/weapons.json
+++ b/lib/weapons.json
@@ -2309,7 +2309,7 @@
   {
     "id": "mw_fuel_rod_gun",
     "name": "Fuel Rod Gun",
-    "mount": "Integrated",
+    "mount": "Main",
     "type": "CQB",
     "damage": [{
       "type": "energy",
@@ -2351,7 +2351,7 @@
   {
     "id": "mw_prototype_1",
     "name": "Prototype Weapon",
-    "mount": "Integrated",
+    "mount": "Main",
     "type": "Special",
     "damage": [{
       "type": "variable",
@@ -2397,7 +2397,7 @@
   {
     "id": "mw_prototype_2",
     "name": "Prototype Weapon",
-    "mount": "Integrated",
+    "mount": "Main",
     "type": "Special",
     "damage": [{
       "type": "variable",
@@ -2443,7 +2443,7 @@
   {
     "id": "mw_prototype_3",
     "name": "Prototype Weapon",
-    "mount": "Integrated",
+    "mount": "Main",
     "type": "Special",
     "damage": [{
       "type": "variable",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lancer-data",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "description": "Data for the LANCER TTRPG",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Fix Scylla's action name - closes #118.
Fix several integrated weapons mount type - closes #117.
Add effect_type to Leviathan and Apocalypse Rail.