### PR TITLE
Remove json data on systems that causes duplicate tags

### DIFF
--- a/lib/systems.json
+++ b/lib/systems.json
@@ -737,9 +737,6 @@
     "id": "ms_charged_stake",
     "name": "CHARGED STAKE",
     "sp": 2,
-    "tags": [{
-      "id": "tg_full_action"
-    }],
     "source": "IPS-N",
     "license": "VLAD",
     "license_level": 3,
@@ -1858,9 +1855,6 @@
     "sp": 2,
     "tags": [{
         "id": "tg_unique"
-      },
-      {
-        "id": "tg_full_tech"
       }
     ],
     "source": "HORUS",
@@ -1923,9 +1917,6 @@
       },
       {
         "id": "tg_unique"
-      },
-      {
-        "id": "tg_full_tech"
       },
       {
         "id": "tg_round",
@@ -2351,9 +2342,6 @@
       {
         "id": "tg_heat_self",
         "val": 4
-      },
-      {
-        "id": "tg_full_action"
       }
     ],
     "source": "HA",
@@ -2441,9 +2429,6 @@
       {
         "id": "tg_heat_self",
         "val": 2
-      },
-      {
-        "id": "tg_full_action"
       }
     ],
     "source": "HA",


### PR DESCRIPTION
Currently, some systems display duplicate tags. For example, the Blinkshield system:
![image](https://user-images.githubusercontent.com/15815322/103650614-97f80280-4f60-11eb-9f59-ee86cc60f86f.png)
According to what I could deduce, systems in comp/con can gain tags in 2 ways:

1. It is in their tag list (I'll call these "manual tags")
2. They contain an action with that tag (I'll call these "inherited tags")

The bug occurs because some systems has both a manual and an inherited version of the same tag.
This PR removes the manual tags for each system I could find that already inherits that tag from elsewhere. 

Fixes massif-press/compcon#1146