### PR TITLE
Added missing "Exposed Reactor" trait to blackbeard

### DIFF
--- a/lib/frames.json
+++ b/lib/frames.json
@@ -165,6 +165,13 @@
         "synergies": [{
           "locations": ["grapple", "boost"],
           "detail": "While grappling, the Blackbeard can Boost and take reactions."
+        },
+      {
+        "name": "Exposed Reactor",
+        "description": "The Blackbeard gains +1 difficulty on Engineering checks and saves.",
+        "synergies": [{
+          "locations": ["engineering", "skill_check"],
+          "detail": "The Blackbeard gains +1 difficulty on Engineering checks and saves."
         }]
       }
     ],


### PR DESCRIPTION
In the book pg. 128, Blackbeard has a trait called "Exposed Reactor", which is missing in the json dataset.

Fixes massif-press/compcon#1142