### PR TITLE
Add a Quick Action for Mimic Mesh system

### DIFF
--- a/lib/systems.json
+++ b/lib/systems.json
@@ -1471,10 +1471,14 @@
     "license": "GORGON",
     "license_level": 1,
     "actions": [{
+      "name": "Activate Mimic Mesh",
+      "activation": "Quick",
+      "detail": "Choose an allied character within Sensors: until the end of your next turn, you gain the Battlefield Awareness reaction." 
+    },
+    {
       "name": "Battlefield Awareness",
       "activation": "Reaction",
       "frequency": "Unlimited",
-      "init": "Choose an allied character within Sensors: until the end of your next turn, you gain the Battlefield Awareness reaction.",
       "trigger": "A hostile action is taken against your target.",
       "detail": "You may move 3 spaces towards your target, by the most direct route possible. This movement interrupts and resolves before the triggering action, ignores engagement and doesn’t provoke reactions. This reaction can be taken as many times per round as it is triggered."
     }],


### PR DESCRIPTION
Mimic Mesh only has a reaction in the list of actions, even though it also involves a quick action.

The syntax has been updated to match the structure of the Napoleon's Stasis Bolt, which works similarly.

fixes massif-press/compcon#1144