### PR TITLE
Remove duplicate tag on autopod

### DIFF
--- a/lib/weapons.json
+++ b/lib/weapons.json
@@ -1430,9 +1430,6 @@
       },
       {
         "id": "tg_unique"
-      },
-      {
-        "id": "tg_reaction"
       }
     ],
     "source": "HORUS",


### PR DESCRIPTION
Explanation is for similar reasons to #134, the Autopod weapon has a double Reaction tag in comp/con. This PR is intended to fix that.

Fixes massif-press/compcon#1235