### PR TITLE
Minotaur Passive and Solidcore Profiles

### DIFF
--- a/lib/frames.json
+++ b/lib/frames.json
@@ -1494,7 +1494,11 @@
       "active_effect": "Choose a character within Sensors: they become Stunned as you hurl their systems into a metaphysical information trap so tangled they can do nothing but try and escape. At the end of their next turn, they can make a Systems save at +3 difficulty. On a success, they are no longer Stunned. This save can be repeated at the end of each of their turns, gaining +1 accuracy each time until successful.",
       "activation": "Full",
       "passive_name": "Metafold Maze",
-      "passive_effect": "Quick Action<br>When you hit with a tech attack, you may activate this system, causing your target to become Slowed until the end of your next turn. If they are already Slowed, they become Immobilized until the end of your next turn; if they are already Immobilized, they become Stunned until the end of your next turn. Each character can only be Stunned by this effect once per combat but can be Slowed or Immobilized any number of times."
+      "passive_actions": [{
+        "name": "Metafold Maze",
+        "activation": "Quick",
+        "detail": "When you hit with a tech attack, you may activate this system, causing your target to become Slowed until the end of your next turn. If they are already Slowed, they become Immobilized until the end of your next turn; if they are already Immobilized, they become Stunned until the end of your next turn. Each character can only be Stunned by this effect once per combat but can be Slowed or Immobilized any number of times."
+      }]
     }
   },
   {

--- a/lib/weapons.json
+++ b/lib/weapons.json
@@ -2288,15 +2288,15 @@
     ],
     "profiles": [{
         "name": "Charge Rail: 4",
-    "damage": [{
-      "override": true,
-      "val": "N/A"
-    }],
-    "range": [{
-      "override": true,
-      "type": "Range",
-      "val": "N/A"
-    }],
+        "damage": [{
+          "override": true,
+          "val": "N/A"
+        }],
+        "range": [{
+          "override": true,
+          "type": "Range",
+          "val": "N/A"
+        }],
         "effect": "Cannot Be Fired"
       },
       {
@@ -2357,15 +2357,57 @@
     "name": "ZF4 SOLIDCORE",
     "mount": "Main",
     "type": "Cannon",
-    "range": [{
-      "type": "Line",
-      "val": "4/Charge"
-    }],
-    "damage": [{
-      "type": "Energy",
-      "val": "1d6/Charge"
-    }],
-    "effect": "This weapon’s profile is determined by the number of Charges it carries. It begins with 1 Charge, dealing 1d6 energy with line 4. Each time you Stabilize, you gain an additional 1 Charge, up to a maximum of 4. The ZF4 gains an additional +4 range and +1d6 energy damage for each charge, and resets to 1 Charge after each attack. Charges persist between scenes, but are lost during a full repair.",
+    "profiles": [
+      {
+        "name": "1 Charge",
+        "range": [{
+            "type": "Line",
+            "val": 4
+          }
+        ],
+        "damage": [{
+          "type": "Energy",
+          "val": "1d6"
+        }],
+        "effect": "This weapon’s profile is determined by the number of Charges it carries. It begins with 1 Charge, dealing 1d6 energy with line 4. Each time you Stabilize, you gain an additional 1 Charge, up to a maximum of 4. The ZF4 gains an additional +4 range and +1d6 energy damage for each charge, and resets to 1 Charge after each attack. Charges persist between scenes, but are lost during a full repair."
+      }, {
+        "name": "2 Charges",
+        "range": [{
+            "type": "Line",
+            "val": 8
+          }
+        ],
+        "damage": [{
+          "type": "Energy",
+          "val": "2d6"
+        }],
+        "effect": "This weapon’s profile is determined by the number of Charges it carries. It begins with 1 Charge, dealing 1d6 energy with line 4. Each time you Stabilize, you gain an additional 1 Charge, up to a maximum of 4. The ZF4 gains an additional +4 range and +1d6 energy damage for each charge, and resets to 1 Charge after each attack. Charges persist between scenes, but are lost during a full repair."
+      }, {
+        "name": "3 Charges",
+        "range": [{
+            "type": "Line",
+            "val": 12
+          }
+        ],
+        "damage": [{
+          "type": "Energy",
+          "val": "3d6"
+        }],
+        "effect": "This weapon’s profile is determined by the number of Charges it carries. It begins with 1 Charge, dealing 1d6 energy with line 4. Each time you Stabilize, you gain an additional 1 Charge, up to a maximum of 4. The ZF4 gains an additional +4 range and +1d6 energy damage for each charge, and resets to 1 Charge after each attack. Charges persist between scenes, but are lost during a full repair."
+      }, {
+        "name": "4 Charges",
+        "range": [{
+            "type": "Line",
+            "val": 16
+          }
+        ],
+        "damage": [{
+          "type": "Energy",
+          "val": "4d6"
+        }],
+        "effect": "This weapon’s profile is determined by the number of Charges it carries. It begins with 1 Charge, dealing 1d6 energy with line 4. Each time you Stabilize, you gain an additional 1 Charge, up to a maximum of 4. The ZF4 gains an additional +4 range and +1d6 energy damage for each charge, and resets to 1 Charge after each attack. Charges persist between scenes, but are lost during a full repair."
+      }
+    ],
     "tags": [{
       "id": "tg_ordnance"
     }]


### PR DESCRIPTION
* Move Minotaur's core passive effect to an `action` instead of text. Closes #144.
* Create 4 profiles for the Sherman's Solidcore, similar to Barbarossa's Apocalypse Rail.

I may take a look at #145, seems like it will take some cross referencing to find everything though. If I don't add that to this PR before you look at it just go ahead and I'll make another if/when I get to it. ;)