### PR TITLE
fix(Compendium):Remove loading tag from Siege Cannon Direct Fire

### DIFF
--- a/lib/weapons.json
+++ b/lib/weapons.json
@@ -1757,15 +1757,12 @@
         }],
     "on_attack": "Choose to fire in either siege mode or direct fire mode.",
     "tags": [{
-            "id": "tg_heat_self",
-            "val": 2
-          },
-          {
             "id": "tg_knockback",
             "val": 2
           },
           {
-            "id": "tg_loading"
+            "id": "tg_heat_self",
+            "val": 2
           }
         ]
       }


### PR DESCRIPTION
# Description

This change removes the Loading tag from Barbarossa's Siege Cannon Direct Fire mode.  It also
rearranges the Direct Fire mode tags to match the book's order & keep the Heat tag in a
consistent position.

## Issue Number

Closes [compcon #1565](https://github.com/massif-press/compcon/issues/1565)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)