### PR TITLE
fix(Reserves):add range/damage fields to Bombardment reserve

### DIFF
--- a/lib/reserves.json
+++ b/lib/reserves.json
@@ -276,7 +276,23 @@
     "actions": [{
       "name": "Bombardment",
       "activation": "Full",
-      "detail": "Call in artillery or orbital bombardment:<br>RANGE 30 within line of sight, BLAST 2, 3d6 explosive damage"
+      "detail": "Call in artillery or orbital bombardment:<br>RANGE 30 within line of sight, BLAST 2, 3d6 explosive damage",
+      "range": [
+        {
+          "type": "Range",
+          "val": 30
+        },
+        {
+          "type": "Blast",
+          "val": 2
+        }
+      ],
+      "damage": [
+        {
+          "type": "Explosive",
+          "val": "3d6"
+        }
+      ]
     }]
   },
   {


### PR DESCRIPTION
Adds damage and range fields to Bombardment reserve since it provides a special "attack"-like action.

As of right now, it seems that the Damage and Range fields of nonstandard actions do not affect the ItemActionDialog boxes in Active Combat mode.  Basically, this change would be vestigial and a low-priority addition until work is done to incorporate those fields.

Feature Request suggesting the aforementioned work: [compcon #1633](https://github.com/massif-press/compcon/issues/1633)