### PR TITLE
fix(Compendium):add no_mods no_core_bonus to Gravity Gun

### DIFF
--- a/lib/weapons.json
+++ b/lib/weapons.json
@@ -1856,6 +1856,8 @@
   {
     "id": "mw_gravity_gun",
     "name": "GRAVITY GUN",
+    "no_mods": true,
+    "no_core_bonus": true,
     "mount": "Heavy",
     "type": "Rifle",
     "damage": [],


### PR DESCRIPTION
# Description
This change prevents the Iskander Gravity Gun from accepting Mods/Core Bonuses, similar to the Pegasus Mimic Gun.

## Issue Number
Closes #127