### PR TITLE
fix(Sitrep):fixed Gauntlet typo 6th->8th

### DIFF
--- a/lib/sitreps.json
+++ b/lib/sitreps.json
@@ -42,7 +42,7 @@
     "name": "Gauntlet",
     "description": "GAUNTLET missions are usually done under duress or when no other options are available, and they usually take place in unfriendly territory. Gauntlet missions require PCs to move through a dangerous area to secure a position.",
     "pcVictory": "At the end of the eighth round, there are more PCs inside the Control Zone than there are enemy characters. Ultras count as 4 characters, elites count as 2, and grunts count as 1/4.",
-    "enemyVictory": "At the end of the sixth round, there are at least as many enemy characters inside the Control Zone as there are PCs.",
+    "enemyVictory": "At the end of the eighth round, there are at least as many enemy characters inside the Control Zone as there are PCs.",
     "deployment": "The PCs deploy first, choosing positions for their characters in the Allied Deployment Zone; next, the GM places the Objective in the Objective Zone.",
     "controlZone": "The area around the EDZ/Control Zone is fortified with Size 1–2 hard cover."
   },


### PR DESCRIPTION
# Description
Fixed minor typo in Gauntlet sitrep victory/defeat conditions: Enemy victory checked on "eighth round" instead of "sixth round".

## Issue Number
Closes [CompCon #1490](https://github.com/massif-press/compcon/issues/1490)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)