### PR TITLE
Stripped Self Heat Tag From Support Shield

### DIFF
--- a/lib/systems.json
+++ b/lib/systems.json
@@ -2858,10 +2858,6 @@
       },
       {
         "id": "tg_shield"
-      },
-      {
-        "id": "tg_heat_self",
-        "val": 2
       }
     ],
     "source": "HA",


### PR DESCRIPTION
Stripped the Self Heat tag from the Saladin's Enclave Support Shield, for reasons listed in https://github.com/massif-press/compcon/issues/1732