### PR TITLE
fix(Data): add Grenade tag to all Grenade systems

### DIFF
--- a/lib/pilot_gear.json
+++ b/lib/pilot_gear.json
@@ -407,6 +407,9 @@
       {
         "id": "tg_limited",
         "val": 2
+      },
+      {
+        "id": "tg_grenade"
       }
     ]
   },

--- a/lib/systems.json
+++ b/lib/systems.json
@@ -90,6 +90,9 @@
       },
       {
         "id": "tg_unique"
+      },
+      {
+        "id": "tg_grenade"
       }
     ],
     "source": "GMS",
@@ -165,6 +168,9 @@
       },
       {
         "id": "tg_unique"
+      },
+      {
+        "id": "tg_grenade"
       }
     ],
     "source": "GMS",
@@ -759,6 +765,9 @@
       },
       {
         "id": "tg_unique"
+      },
+      {
+        "id": "tg_grenade"
       }
     ],
     "source": "IPS-N",
@@ -1268,6 +1277,9 @@
       },
       {
         "id": "tg_unique"
+      },
+      {
+        "id": "tg_grenade"
       }
     ],
     "source": "SSC",
@@ -2115,6 +2127,9 @@
       },
       {
         "id": "tg_unique"
+      },
+      {
+        "id": "tg_grenade"
       }
     ],
     "source": "HORUS",
@@ -2354,6 +2369,9 @@
       },
       {
         "id": "tg_unique"
+      },
+      {
+        "id": "tg_grenade"
       }
     ],
     "source": "HA",
@@ -2511,6 +2529,9 @@
       },
       {
         "id": "tg_unique"
+      },
+      {
+        "id": "tg_grenade"
       }
     ],
     "source": "HA",
@@ -2614,6 +2635,9 @@
       },
       {
         "id": "tg_unique"
+      },
+      {
+        "id": "tg_grenade"
       }
     ],
     "source": "HA",


### PR DESCRIPTION
# Description
This change adds the Grenade tag to all systems/gear that use grenade actions.  Compcon seems to automatically add the "Mine" tag if one of the deployables has the type "mine" but doesn't possess a similar check for grenades; the easiest approach seems to be adding the Grenade tag itself.

## Issue Number
Closes #164, though tags should be added to other official Massif LCPs, as well.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)