### PR TITLE
Grenade Line of Sight Duplicate Text

### DIFF
--- a/lib/tags.json
+++ b/lib/tags.json
@@ -141,7 +141,7 @@
   {
     "id": "tg_grenade",
     "name": "GRENADE",
-    "description": "As a quick action, this explosive or other device can be thrown to a space within line of sight and the specified Range and line of sight."
+    "description": "As a quick action, this explosive or other device can be thrown to a space within line of sight and the specified Range."
   },
   {
     "id": "tg_heat_self",


### PR DESCRIPTION
Eliminates saying line of sight twice in the Grenade tag.