### PR TITLE
fix Sentinel Drone typo

### DIFF
--- a/lib/systems.json
+++ b/lib/systems.json
@@ -1824,7 +1824,7 @@
         "hp": 5,
         "edef": 10,
         "evasion": 10,
-        "detail": "The sentinel drone drone can be deployed to any free space within Sensors and line of sight, where it establishes a burst 2 security perimeter. Hostile characters within the affected area take 3 kinetic damage from the drone’s automatic fire before making any attack.",
+        "detail": "The sentinel drone can be deployed to any free space within Sensors and line of sight, where it establishes a burst 2 security perimeter. Hostile characters within the affected area take 3 kinetic damage from the drone’s automatic fire before making any attack.",
         "recall": "Quick",
         "redeploy": "Quick"
       }


### PR DESCRIPTION
# Description
This fixes a minor typo in Gorgon 1's Sentinel Drone mechanical text.  Typo was in the printed Lancer Core Book and carried over to CompCon.  Documented the typo in [Lancer-Community-Edition#953]( https://github.com/AshleyMoni/Lancer-Community-Edition/issues/953).

## Issue Number
Closes [CompCon #1855](https://github.com/massif-press/compcon/issues/1855)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)