### PR TITLE
fix(data): add empty damage to Latch Drone

### DIFF
--- a/lib/weapons.json
+++ b/lib/weapons.json
@@ -2248,6 +2248,7 @@
     "name": "Latch Drone",
     "mount": "Main",
     "type": "Launcher",
+    "damage": [],
     "range": [{
       "type": "Range",
       "val": 8


### PR DESCRIPTION
# Description
This adds a `damage` field to Latch Drone to make sure it plays nice with External Batteries and other damage-check systems.

## Issue Number
Partially addresses [CompCon #1875](https://github.com/massif-press/compcon/issues/1875)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)