### PR TITLE
Changing names of weapons, systems, and mods to better match the formatting of the rulebook.

### DIFF
--- a/lib/mods.json
+++ b/lib/mods.json
@@ -15,7 +15,7 @@
   },
   {
     "id": "wm_thermal_charge",
-    "name": "THERMAL CHARGE",
+    "name": "Thermal Charge",
     "sp": 2,
     "allowed_types": [
       "Melee"
@@ -43,7 +43,7 @@
   },
   {
     "id": "wm_uncle_class_comp_con",
-    "name": "UNCLE-CLASS COMP/CON",
+    "name": "UNCLE-Class Comp/Con",
     "sp": 3,
     "allowed_types": [
       "Melee",
@@ -75,7 +75,7 @@
   },
   {
     "id": "wm_throughbolt_rounds",
-    "name": "THROUGHBOLT ROUNDS",
+    "name": "Throughbolt Rounds",
     "sp": 2,
     "allowed_types": [
       "CQB",
@@ -95,7 +95,7 @@
   },
   {
     "id": "wm_shock_wreath",
-    "name": "SHOCK WREATH",
+    "name": "Shock Wreath",
     "sp": 2,
     "allowed_types": [
       "Melee"
@@ -120,7 +120,7 @@
   },
   {
     "id": "wm_stabilizer_mod",
-    "name": "STABILIZER MOD",
+    "name": "Stabilizer Mod",
     "sp": 2,
     "allowed_types": [
       "Launcher",
@@ -145,7 +145,7 @@
   },
   {
     "id": "wm_nanocomposite_adaptation",
-    "name": "NANOCOMPOSITE ADAPTATION",
+    "name": "Nanocomposite Adaptation",
     "sp": 2,
     "allowed_types": [
       "Melee",
@@ -171,7 +171,7 @@
   },
   {
     "id": "wm_phase_ready_mod",
-    "name": "PHASE-READY MOD",
+    "name": "Phase-Ready Mod",
     "sp": 2,
     "allowed_types": [
       "Melee",
@@ -189,7 +189,7 @@
   },
   {
     "id": "wm_paracausal_mod",
-    "name": "PARACAUSAL MOD",
+    "name": "Paracausal Mod",
     "sp": 4,
     "allowed_types": [
       "Melee",

--- a/lib/systems.json
+++ b/lib/systems.json
@@ -12,7 +12,7 @@
   },
   {
     "id": "ms_comp_con_class_assistant_unit",
-    "name": "COMP/CON-CLASS ASSISTANT UNIT",
+    "name": "Comp/Con-Class Assistant Unit",
     "type": "AI",
     "sp": 2,
     "tags": [
@@ -34,7 +34,7 @@
   },
   {
     "id": "ms_custom_paint_job",
-    "name": "CUSTOM PAINT JOB",
+    "name": "Custom Paint Job",
     "sp": 1,
     "tags": [
       {
@@ -51,7 +51,7 @@
   },
   {
     "id": "ms_expanded_compartment",
-    "name": "EXPANDED COMPARTMENT",
+    "name": "Expanded Compartment",
     "sp": 1,
     "tags": [
       {
@@ -65,7 +65,7 @@
   },
   {
     "id": "ms_manipulators",
-    "name": "MANIPULATORS",
+    "name": "Manipulators",
     "sp": 1,
     "tags": [
       {
@@ -80,7 +80,7 @@
   },
   {
     "id": "ms_pattern_a_smoke_charges",
-    "name": "PATTERN-A SMOKE CHARGES",
+    "name": "Pattern-A Smoke Charges",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -131,7 +131,7 @@
   },
   {
     "id": "ms_pattern_a_jericho_deployable_cover",
-    "name": "PATTERN-A JERICHO DEPLOYABLE COVER",
+    "name": "Pattern-A Jericho Deployable Cover",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -158,7 +158,7 @@
   },
   {
     "id": "ms_pattern_b_hex_charges",
-    "name": "PATTERN-B HEX CHARGES",
+    "name": "Pattern-B HEX Charges",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -216,7 +216,7 @@
   },
   {
     "id": "ms_personalizations",
-    "name": "PERSONALIZATIONS",
+    "name": "Personalizations",
     "sp": 1,
     "tags": [
       {
@@ -236,7 +236,7 @@
   },
   {
     "id": "ms_stable_structure",
-    "name": "STABLE STRUCTURE",
+    "name": "Stable Structure",
     "sp": 2,
     "tags": [
       {
@@ -250,7 +250,7 @@
   },
   {
     "id": "ms_turret_drones",
-    "name": "TURRET DRONES",
+    "name": "Turret Drones",
     "type": "Drone",
     "sp": 2,
     "tags": [
@@ -290,7 +290,7 @@
   },
   {
     "id": "ms_type_3_projected_shield",
-    "name": "TYPE-3 PROJECTED SHIELD",
+    "name": "Type-3 Projected Shield",
     "type": "Shield",
     "sp": 2,
     "tags": [
@@ -319,7 +319,7 @@
   },
   {
     "id": "ms_eva_module",
-    "name": "EVA MODULE",
+    "name": "EVA Module",
     "type": "Flight System",
     "sp": 1,
     "tags": [
@@ -342,7 +342,7 @@
   },
   {
     "id": "ms_rapid_burst_jump_jet_system",
-    "name": "RAPID BURST JUMP JET SYSTEM",
+    "name": "Rapid Burst Jump Jet System",
     "type": "Flight System",
     "sp": 2,
     "tags": [
@@ -365,7 +365,7 @@
   },
   {
     "id": "ms_type_i_flight_system",
-    "name": "TYPE-I FLIGHT SYSTEM",
+    "name": "Type-I Flight System",
     "type": "Flight System",
     "sp": 3,
     "tags": [
@@ -388,7 +388,7 @@
   },
   {
     "id": "ms_synthetic_muscle_netting",
-    "name": "SYNTHETIC MUSCLE NETTING",
+    "name": "Synthetic Muscle Netting",
     "sp": 2,
     "tags": [
       {
@@ -417,7 +417,7 @@
   },
   {
     "id": "ms_reinforced_cabling",
-    "name": "REINFORCED CABLING",
+    "name": "Reinforced Cabling",
     "sp": 2,
     "source": "IPS-N",
     "license": "BLACKBEARD",
@@ -438,7 +438,7 @@
   },
   {
     "id": "ms_sekhmet_class_nhp",
-    "name": "SEKHMET-CLASS NHP",
+    "name": "SEKHMET-Class NHP",
     "type": "AI",
     "sp": 3,
     "tags": [
@@ -463,7 +463,7 @@
   },
   {
     "id": "ms_argonaut_shield",
-    "name": "ARGONAUT SHIELD",
+    "name": "Argonaut Shield",
     "sp": 2,
     "tags": [
       {
@@ -483,7 +483,7 @@
   },
   {
     "id": "ms_aegis_shield_generator",
-    "name": "AEGIS SHIELD GENERATOR",
+    "name": "Aegis Shield Generator",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -528,7 +528,7 @@
   },
   {
     "id": "ms_portable_bunker",
-    "name": "PORTABLE BUNKER",
+    "name": "Portable Bunker",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -560,7 +560,7 @@
   },
   {
     "id": "ms_cable_winch_system",
-    "name": "CABLE WINCH SYSTEM",
+    "name": "Cable Winch System",
     "sp": 1,
     "source": "IPS-N",
     "license": "LANCASTER",
@@ -575,7 +575,7 @@
   },
   {
     "id": "ms_restock_drone",
-    "name": "RESTOCK DRONE",
+    "name": "Restock Drone",
     "type": "Drone",
     "sp": 2,
     "tags": [
@@ -614,7 +614,7 @@
   },
   {
     "id": "ms_mule_harness",
-    "name": "MULE HARNESS",
+    "name": "MULE Harness",
     "sp": 2,
     "tags": [
       {
@@ -629,7 +629,7 @@
   },
   {
     "id": "ms_whitewash_sealant_spray",
-    "name": "WHITEWASH SEALANT SPRAY",
+    "name": "Whitewash Sealant Spray",
     "sp": 2,
     "source": "IPS-N",
     "license": "LANCASTER",
@@ -644,7 +644,7 @@
   },
   {
     "id": "ms_aceso_stabilizer",
-    "name": "ACESO STABILIZER",
+    "name": "Aceso Stabilizer",
     "type": "Shield",
     "sp": 3,
     "tags": [
@@ -675,7 +675,7 @@
   },
   {
     "id": "ms_bulwark_mods",
-    "name": "BULWARK MODS",
+    "name": "Bulwark Mods",
     "sp": 1,
     "tags": [
       {
@@ -698,7 +698,7 @@
   },
   {
     "id": "ms_armor_lock_plating",
-    "name": "ARMOR-LOCK PLATING",
+    "name": "Armor-Lock Plating",
     "sp": 1,
     "tags": [
       {
@@ -731,7 +731,7 @@
   },
   {
     "id": "ms_ramjet",
-    "name": "RAMJET",
+    "name": "Ramjet",
     "sp": 3,
     "tags": [
       {
@@ -755,7 +755,7 @@
   },
   {
     "id": "ms_bb_breach_blast_charges",
-    "name": "BB BREACH/BLAST CHARGES",
+    "name": "BB Breach/Blast Charges",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -813,7 +813,7 @@
   },
   {
     "id": "ms_roland_chamber",
-    "name": "“ROLAND” CHAMBER",
+    "name": "“Roland” Chamber",
     "sp": 3,
     "tags": [
       {
@@ -828,7 +828,7 @@
   },
   {
     "id": "ms_siege_ram",
-    "name": "SIEGE RAM",
+    "name": "Siege Ram",
     "sp": 2,
     "tags": [
       {
@@ -851,7 +851,7 @@
   },
   {
     "id": "ms_hyperdense_armor",
-    "name": "HYPERDENSE ARMOR",
+    "name": "HyperDense Armor",
     "type": "Shield",
     "sp": 3,
     "tags": [
@@ -880,7 +880,7 @@
   },
   {
     "id": "ms_webjaw_snare",
-    "name": "WEBJAW SNARE",
+    "name": "Webjaw Snare",
     "type": "Deployable",
     "sp": 1,
     "tags": [
@@ -911,7 +911,7 @@
   },
   {
     "id": "ms_caltrop_launcher",
-    "name": "CALTROP LAUNCHER",
+    "name": "Caltrop Launcher",
     "sp": 1,
     "tags": [
       {
@@ -931,7 +931,7 @@
   },
   {
     "id": "ms_charged_stake",
-    "name": "CHARGED STAKE",
+    "name": "Charged Stake",
     "sp": 2,
     "source": "IPS-N",
     "license": "VLAD",
@@ -946,7 +946,7 @@
   },
   {
     "id": "ms_ferrous_lash",
-    "name": "FERROUS LASH",
+    "name": "Ferrous Lash",
     "sp": 2,
     "source": "SSC",
     "license": "BLACK WITCH",
@@ -961,7 +961,7 @@
   },
   {
     "id": "ms_iceout_drone",
-    "name": "ICEOUT DRONE",
+    "name": "ICEOUT Drone",
     "type": "Drone",
     "sp": 2,
     "tags": [
@@ -1000,7 +1000,7 @@
   },
   {
     "id": "ms_perimeter_command_plate",
-    "name": "PERIMETER COMMAND PLATE",
+    "name": "Perimeter Command Plate",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -1025,7 +1025,7 @@
   },
   {
     "id": "ms_black_ice_module",
-    "name": "BLACK ICE MODULE",
+    "name": "Black ICE Module",
     "type": "Tech",
     "sp": 3,
     "tags": [
@@ -1041,7 +1041,7 @@
     "counters": [
       {
         "id": "ctr_black_ice_module",
-        "name": "BLACK ICE MODULE",
+        "name": "Black ICE Module",
         "default_value": 1,
         "min": 1,
         "max": 3
@@ -1050,7 +1050,7 @@
   },
   {
     "id": "ms_magnetic_shield",
-    "name": "MAGNETIC SHIELD",
+    "name": "Magnetic Shield",
     "type": "Shield",
     "sp": 2,
     "tags": [
@@ -1074,7 +1074,7 @@
   },
   {
     "id": "ms_high_stress_mag_clamps",
-    "name": "HIGH-STRESS MAG CLAMPS",
+    "name": "High-Stress Mag Clamps",
     "sp": 1,
     "tags": [
       {
@@ -1097,7 +1097,7 @@
   },
   {
     "id": "ms_tracking_bug",
-    "name": "TRACKING BUG",
+    "name": "Tracking Bug",
     "type": "Tech",
     "sp": 2,
     "source": "SSC",
@@ -1114,7 +1114,7 @@
   },
   {
     "id": "ms_core_siphon",
-    "name": "CORE SIPHON",
+    "name": "Core Siphon",
     "sp": 2,
     "tags": [
       {
@@ -1134,7 +1134,7 @@
   },
   {
     "id": "ms_kinetic_compensator",
-    "name": "KINETIC COMPENSATOR",
+    "name": "Kinetic Compensator",
     "sp": 2,
     "tags": [
       {
@@ -1164,7 +1164,7 @@
   },
   {
     "id": "ms_neurospike",
-    "name": "NEUROSPIKE",
+    "name": "Neurospike",
     "type": "Tech",
     "sp": 2,
     "tags": [
@@ -1191,7 +1191,7 @@
   },
   {
     "id": "ms_flicker_field_projector",
-    "name": "FLICKER FIELD PROJECTOR",
+    "name": "Flicker Field Projector",
     "sp": 1,
     "tags": [
       {
@@ -1215,7 +1215,7 @@
   },
   {
     "id": "ms_stuncrown",
-    "name": "STUNCROWN",
+    "name": "StunCrown",
     "sp": 2,
     "tags": [
       {
@@ -1239,7 +1239,7 @@
   },
   {
     "id": "ms_oasis_wall",
-    "name": "OASIS WALL",
+    "name": "OASIS Wall",
     "type": "Shield",
     "sp": 3,
     "tags": [
@@ -1267,7 +1267,7 @@
   },
   {
     "id": "ms_flash_charges",
-    "name": "FLASH CHARGES",
+    "name": "Flash Charges",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -1318,7 +1318,7 @@
   },
   {
     "id": "ms_reactive_weave",
-    "name": "REACTIVE WEAVE",
+    "name": "Reactive Weave",
     "sp": 1,
     "tags": [
       {
@@ -1341,7 +1341,7 @@
   },
   {
     "id": "ms_active_camouflage",
-    "name": "ACTIVE CAMOUFLAGE",
+    "name": "Active Camouflage",
     "sp": 3,
     "tags": [
       {
@@ -1365,7 +1365,7 @@
   },
   {
     "id": "ms_javelin_rockets",
-    "name": "JAVELIN ROCKETS",
+    "name": "Javelin Rockets",
     "sp": 2,
     "tags": [
       {
@@ -1385,7 +1385,7 @@
   },
   {
     "id": "ms_tlaloc_class_nhp",
-    "name": "TLALOC-CLASS NHP",
+    "name": "TLALOC-Class NHP",
     "type": "AI",
     "sp": 3,
     "tags": [
@@ -1414,7 +1414,7 @@
   },
   {
     "id": "ms_hunter_logic_suite",
-    "name": "HUNTER LOGIC SUITE",
+    "name": "Hunter Logic Suite",
     "type": "Tech",
     "sp": 2,
     "tags": [
@@ -1441,7 +1441,7 @@
   },
   {
     "id": "ms_singularity_motivator",
-    "name": "SINGULARITY MOTIVATOR",
+    "name": "Singularity Motivator",
     "sp": 2,
     "tags": [
       {
@@ -1464,7 +1464,7 @@
   },
   {
     "id": "ms_fade_cloak",
-    "name": "FADE CLOAK",
+    "name": "FADE Cloak",
     "sp": 2,
     "tags": [
       {
@@ -1484,7 +1484,7 @@
   },
   {
     "id": "ms_lotus_projector",
-    "name": "LOTUS PROJECTOR",
+    "name": "Lotus Projector",
     "type": "Drone",
     "sp": 2,
     "tags": [
@@ -1517,7 +1517,7 @@
   },
   {
     "id": "ms_markerlight",
-    "name": "MARKERLIGHT",
+    "name": "Markerlight",
     "type": "Tech",
     "sp": 2,
     "source": "SSC",
@@ -1534,7 +1534,7 @@
   },
   {
     "id": "ms_retractable_profile",
-    "name": "RETRACTABLE PROFILE",
+    "name": "Retractable Profile",
     "type": "Tech",
     "sp": 1,
     "tags": [
@@ -1555,7 +1555,7 @@
   },
   {
     "id": "ms_athena_class_nhp",
-    "name": "ATHENA-CLASS NHP",
+    "name": "ATHENA-Class NHP",
     "type": "AI",
     "sp": 3,
     "tags": [
@@ -1581,7 +1581,7 @@
   },
   {
     "id": "ms_lb_oc_cloaking_field",
-    "name": "LB/OC CLOAKING FIELD",
+    "name": "LB/OC Cloaking Field",
     "sp": 4,
     "tags": [
       {
@@ -1602,7 +1602,7 @@
   },
   {
     "id": "ms_hive_drone",
-    "name": "HIVE DRONE",
+    "name": "Hive Drone",
     "type": "Drone",
     "sp": 2,
     "source": "HORUS",
@@ -1625,7 +1625,7 @@
   },
   {
     "id": "ms_scanner_swarm",
-    "name": "SCANNER SWARM",
+    "name": "Scanner Swarm",
     "type": "Tech",
     "sp": 1,
     "tags": [
@@ -1641,7 +1641,7 @@
   },
   {
     "id": "ms_swarm_body",
-    "name": "SWARM BODY",
+    "name": "Swarm Body",
     "sp": 2,
     "tags": [
       {
@@ -1661,7 +1661,7 @@
   },
   {
     "id": "ms_h0r_os_system_upgrade_i",
-    "name": "H0R_OS SYSTEM UPGRADE I",
+    "name": "H0R_OS System Upgrade I",
     "type": "Tech",
     "sp": 2,
     "tags": [
@@ -1688,7 +1688,7 @@
   },
   {
     "id": "ms_metahook",
-    "name": "METAHOOK",
+    "name": "Metahook",
     "type": "Tech",
     "sp": 2,
     "tags": [
@@ -1709,7 +1709,7 @@
   },
   {
     "id": "ms_h0r_os_system_upgrade_ii",
-    "name": "H0R_OS SYSTEM UPGRADE II",
+    "name": "H0R_OS System Upgrade II",
     "type": "Tech",
     "sp": 2,
     "tags": [
@@ -1736,7 +1736,7 @@
   },
   {
     "id": "ms_osiris_class_nhp",
-    "name": "OSIRIS-CLASS NHP",
+    "name": "OSIRIS-Class NHP",
     "type": "AI",
     "sp": 3,
     "tags": [
@@ -1766,7 +1766,7 @@
   },
   {
     "id": "ms_h0r_os_system_upgrade_iii",
-    "name": "H0R_OS SYSTEM UPGRADE III",
+    "name": "H0R_OS System Upgrade III",
     "type": "Tech",
     "sp": 2,
     "tags": [
@@ -1793,7 +1793,7 @@
   },
   {
     "id": "ms_mimic_mesh",
-    "name": "MIMIC MESH",
+    "name": "Mimic Mesh",
     "sp": 2,
     "tags": [
       {
@@ -1822,7 +1822,7 @@
   },
   {
     "id": "ms_sentinel_drone",
-    "name": "SENTINEL DRONE",
+    "name": "Sentinel Drone",
     "type": "Drone",
     "sp": 2,
     "source": "HORUS",
@@ -1861,7 +1861,7 @@
   },
   {
     "id": "ms_monitor_module",
-    "name": "MONITOR MODULE",
+    "name": "Monitor Module",
     "sp": 2,
     "tags": [
       {
@@ -1880,7 +1880,7 @@
     "counters": [
       {
         "id": "ctr_monitor_module",
-        "name": "MONITOR MODULE",
+        "name": "Monitor Module",
         "default_value": 0,
         "min": 0,
         "max": 3
@@ -1890,7 +1890,7 @@
   },
   {
     "id": "ms_scylla_class_nhp",
-    "name": "SCYLLA-CLASS NHP",
+    "name": "SCYLLA-Class NHP",
     "type": "AI",
     "sp": 3,
     "tags": [
@@ -1954,7 +1954,7 @@
   },
   {
     "id": "ms_tempest_drone",
-    "name": "TEMPEST DRONE",
+    "name": "Tempest Drone",
     "type": "Drone",
     "sp": 2,
     "source": "HORUS",
@@ -1987,7 +1987,7 @@
   },
   {
     "id": "ms_assassin_drone",
-    "name": "ASSASSIN DRONE",
+    "name": "Assassin Drone",
     "type": "Drone",
     "sp": 2,
     "source": "HORUS",
@@ -2019,7 +2019,7 @@
   },
   {
     "id": "ms_beckoner",
-    "name": "BECKONER",
+    "name": "Beckoner",
     "type": "Tech",
     "sp": 2,
     "tags": [
@@ -2046,7 +2046,7 @@
   },
   {
     "id": "ms_smite",
-    "name": "SMITE",
+    "name": "Smite",
     "type": "Tech",
     "sp": 3,
     "tags": [
@@ -2073,7 +2073,7 @@
   },
   {
     "id": "ms_emp_pulse",
-    "name": "EMP PULSE",
+    "name": "EMP Pulse",
     "sp": 2,
     "tags": [
       {
@@ -2093,7 +2093,7 @@
   },
   {
     "id": "ms_lightning_generator",
-    "name": "LIGHTNING GENERATOR",
+    "name": "Lightning Generator",
     "sp": 3,
     "tags": [
       {
@@ -2117,7 +2117,7 @@
   },
   {
     "id": "ms_mesmer_charges",
-    "name": "MESMER CHARGES",
+    "name": "Mesmer Charges",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -2165,7 +2165,7 @@
   },
   {
     "id": "ms_viral_logic_suite",
-    "name": "VIRAL LOGIC SUITE",
+    "name": "Viral Logic Suite",
     "type": "Tech",
     "sp": 2,
     "tags": [
@@ -2192,7 +2192,7 @@
   },
   {
     "id": "ms_aggressive_system_sync",
-    "name": "AGGRESSIVE SYSTEM SYNC",
+    "name": "Aggressive System Sync",
     "type": "Tech",
     "sp": 2,
     "source": "HORUS",
@@ -2216,7 +2216,7 @@
   },
   {
     "id": "ms_metafold_carver",
-    "name": "METAFOLD CARVER",
+    "name": "Metafold Carver",
     "type": "Tech",
     "sp": 2,
     "tags": [],
@@ -2239,7 +2239,7 @@
   },
   {
     "id": "ms_interdiction_field",
-    "name": "INTERDICTION FIELD",
+    "name": "Interdiction Field",
     "sp": 3,
     "source": "HORUS",
     "license": "MINOTAUR",
@@ -2254,7 +2254,7 @@
   },
   {
     "id": "ms_law_of_blades",
-    "name": "LAW OF BLADES",
+    "name": "Law of Blades",
     "type": "Tech",
     "sp": 2,
     "tags": [
@@ -2283,7 +2283,7 @@
   },
   {
     "id": "ms_hunter_lock",
-    "name": "HUNTER LOCK",
+    "name": "Hunter Lock",
     "sp": 2,
     "tags": [
       {
@@ -2303,7 +2303,7 @@
   },
   {
     "id": "ms_eye_of_horus",
-    "name": "EYE OF HORUS",
+    "name": "Eye of HORUS",
     "sp": 3,
     "tags": [
       {
@@ -2323,7 +2323,7 @@
   },
   {
     "id": "ms_sisyphus_class_nhp",
-    "name": "SISYPHUS-CLASS NHP",
+    "name": "SISYPHUS-Class NHP",
     "type": "AI",
     "sp": 2,
     "tags": [
@@ -2359,7 +2359,7 @@
   },
   {
     "id": "ms_roller_directed_payload_charges",
-    "name": "“ROLLER” DIRECTED PAYLOAD CHARGES",
+    "name": "“Roller” Directed Payload Charges",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -2411,7 +2411,7 @@
   },
   {
     "id": "ms_siege_stabilizers",
-    "name": "SIEGE STABILIZERS",
+    "name": "Siege Stabilizers",
     "sp": 1,
     "tags": [
       {
@@ -2431,7 +2431,7 @@
   },
   {
     "id": "ms_autoloader_drone",
-    "name": "AUTOLOADER DRONE",
+    "name": "Autoloader Drone",
     "type": "Drone",
     "sp": 2,
     "tags": [
@@ -2461,7 +2461,7 @@
   },
   {
     "id": "ms_flak_launcher",
-    "name": "FLAK LAUNCHER",
+    "name": "Flak Launcher",
     "sp": 2,
     "source": "HA",
     "license": "BARBAROSSA",
@@ -2476,7 +2476,7 @@
   },
   {
     "id": "ms_external_ammo_feed",
-    "name": "EXTERNAL AMMO FEED",
+    "name": "External Ammo Feed",
     "sp": 3,
     "tags": [
       {
@@ -2500,7 +2500,7 @@
   },
   {
     "id": "ms_explosive_vents",
-    "name": "EXPLOSIVE VENTS",
+    "name": "Explosive Vents",
     "sp": 2,
     "tags": [
       {
@@ -2519,7 +2519,7 @@
   },
   {
     "id": "ms_havok_charges",
-    "name": "HAVOK CHARGES",
+    "name": "HAVOK Charges",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -2576,7 +2576,7 @@
   },
   {
     "id": "ms_auto_cooler",
-    "name": "AUTO-COOLER",
+    "name": "Auto-Cooler",
     "sp": 2,
     "tags": [
       {
@@ -2596,7 +2596,7 @@
   },
   {
     "id": "ms_agni_class_nhp",
-    "name": "AGNI-CLASS NHP",
+    "name": "AGNI-Class NHP",
     "type": "AI",
     "sp": 3,
     "tags": [
@@ -2625,7 +2625,7 @@
   },
   {
     "id": "ms_grounding_charges",
-    "name": "GROUNDING CHARGES",
+    "name": "Grounding Charges",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -2673,7 +2673,7 @@
   },
   {
     "id": "ms_repulser_field",
-    "name": "REPULSER FIELD",
+    "name": "Repulser Field",
     "sp": 1,
     "tags": [
       {
@@ -2697,7 +2697,7 @@
   },
   {
     "id": "ms_clamp_bombs",
-    "name": "CLAMP BOMBS",
+    "name": "Clamp Bombs",
     "sp": 2,
     "tags": [
       {
@@ -2722,7 +2722,7 @@
   },
   {
     "id": "ms_tesseract",
-    "name": "TESSERACT",
+    "name": "Tesseract",
     "type": "Tech",
     "sp": 2,
     "tags": [
@@ -2749,7 +2749,7 @@
   },
   {
     "id": "ms_stasis_bolt",
-    "name": "STASIS BOLT",
+    "name": "Stasis Bolt",
     "type": "Shield",
     "sp": 1,
     "tags": [
@@ -2782,7 +2782,7 @@
   },
   {
     "id": "ms_stasis_generator",
-    "name": "STASIS GENERATOR",
+    "name": "Stasis Generator",
     "type": "Shield",
     "sp": 2,
     "tags": [
@@ -2806,7 +2806,7 @@
   },
   {
     "id": "ms_stasis_barrier",
-    "name": "STASIS BARRIER",
+    "name": "Stasis Barrier",
     "type": "Deployable",
     "sp": 2,
     "tags": [
@@ -2845,7 +2845,7 @@
   },
   {
     "id": "ms_blinkshield",
-    "name": "BLINKSHIELD",
+    "name": "Blinkshield",
     "type": "Shield",
     "sp": 2,
     "tags": [
@@ -2873,7 +2873,7 @@
   },
   {
     "id": "ms_enclave_pattern_support_shield",
-    "name": "ENCLAVE-PATTERN SUPPORT SHIELD",
+    "name": "ENCLAVE-Pattern Support Shield",
     "type": "Shield",
     "sp": 2,
     "tags": [
@@ -2906,7 +2906,7 @@
   },
   {
     "id": "ms_flash_anchor",
-    "name": "FLASH ANCHOR",
+    "name": "Flash Anchor",
     "type": "Shield",
     "sp": 1,
     "tags": [
@@ -2937,7 +2937,7 @@
   },
   {
     "id": "ms_hardlight_defense_system",
-    "name": "HARDLIGHT DEFENSE SYSTEM",
+    "name": "Hardlight Defense System",
     "type": "Shield",
     "sp": 3,
     "tags": [
@@ -2970,7 +2970,7 @@
   },
   {
     "id": "ms_noah_class_nhp",
-    "name": "NOAH-CLASS NHP",
+    "name": "NOAH-Class NHP",
     "type": "AI",
     "sp": 3,
     "tags": [
@@ -2995,7 +2995,7 @@
   },
   {
     "id": "ms_reactor_stabilizer",
-    "name": "REACTOR STABILIZER",
+    "name": "Reactor Stabilizer",
     "sp": 3,
     "tags": [
       {
@@ -3010,7 +3010,7 @@
   },
   {
     "id": "ms_redundant_systems_upgrade",
-    "name": "REDUNDANT SYSTEMS UPGRADE",
+    "name": "Redundant Systems Upgrade",
     "sp": 3,
     "tags": [
       {
@@ -3034,7 +3034,7 @@
   },
   {
     "id": "ms_asura_class_nhp",
-    "name": "ASURA-CLASS NHP",
+    "name": "ASURA-Class NHP",
     "type": "AI",
     "sp": 3,
     "tags": [
@@ -3067,7 +3067,7 @@
   },
   {
     "id": "ms_external_batteries",
-    "name": "EXTERNAL BATTERIES",
+    "name": "External Batteries",
     "sp": 2,
     "tags": [
       {
@@ -3114,7 +3114,7 @@
   },
   {
     "id": "ms_deep_well_heat_sink",
-    "name": "DEEP WELL HEAT SINK",
+    "name": "Deep Well Heat Sink",
     "sp": 4,
     "tags": [
       {
@@ -3129,7 +3129,7 @@
   },
   {
     "id": "ms_lucifer_class_nhp",
-    "name": "LUCIFER-CLASS NHP",
+    "name": "LUCIFER-Class NHP",
     "type": "AI",
     "sp": 3,
     "tags": [
@@ -3162,7 +3162,7 @@
   },
   {
     "id": "ms_plasma_gauntlet",
-    "name": "PLASMA GAUNTLET",
+    "name": "Plasma Gauntlet",
     "sp": 2,
     "tags": [
       {

--- a/lib/weapons.json
+++ b/lib/weapons.json
@@ -14,7 +14,7 @@
   },
   {
     "id": "mw_anti_materiel_rifle",
-    "name": "ANTI-MATERIEL RIFLE",
+    "name": "Anti-Materiel Rifle",
     "mount": "Heavy",
     "type": "Rifle",
     "damage": [{
@@ -45,7 +45,7 @@
   },
   {
     "id": "mw_assault_rifle",
-    "name": "ASSAULT RIFLE",
+    "name": "Assault Rifle",
     "mount": "Main",
     "type": "Rifle",
     "damage": [{
@@ -67,7 +67,7 @@
   },
   {
     "id": "mw_charged_blade",
-    "name": "CHARGED BLADE",
+    "name": "Charged Blade",
     "mount": "Main",
     "type": "Melee",
     "damage": [{
@@ -88,7 +88,7 @@
   },
   {
     "id": "mw_cyclone_pulse_rifle",
-    "name": "CYCLONE PULSE RIFLE",
+    "name": "Cyclone Pulse Rifle",
     "mount": "Superheavy",
     "type": "Rifle",
     "damage": [{
@@ -117,7 +117,7 @@
   },
   {
     "id": "mw_heavy_charged_blade",
-    "name": "HEAVY CHARGED BLADE",
+    "name": "Heavy Charged Blade",
     "mount": "Heavy",
     "type": "Melee",
     "damage": [{
@@ -138,7 +138,7 @@
   },
   {
     "id": "mw_heavy_machine_gun",
-    "name": "HEAVY MACHINE GUN",
+    "name": "Heavy Machine Gun",
     "mount": "Heavy",
     "type": "Cannon",
     "damage": [{
@@ -159,7 +159,7 @@
   },
   {
     "id": "mw_heavy_melee_weapon",
-    "name": "HEAVY MELEE WEAPON",
+    "name": "Heavy Melee Weapon",
     "mount": "Heavy",
     "type": "Melee",
     "damage": [{
@@ -177,7 +177,7 @@
   },
   {
     "id": "mw_howitzer",
-    "name": "HOWITZER",
+    "name": "Howitzer",
     "mount": "Heavy",
     "type": "Cannon",
     "damage": [{
@@ -213,7 +213,7 @@
   },
   {
     "id": "mw_missile_rack",
-    "name": "MISSILE RACK",
+    "name": "Missile Rack",
     "mount": "Auxiliary",
     "type": "Launcher",
     "damage": [{
@@ -239,7 +239,7 @@
   },
   {
     "id": "mw_mortar",
-    "name": "MORTAR",
+    "name": "Mortar",
     "mount": "Main",
     "type": "Cannon",
     "damage": [{
@@ -269,7 +269,7 @@
   },
   {
     "id": "mw_nexus_hunter_killer",
-    "name": "NEXUS (HUNTER-KILLER)",
+    "name": "Nexus (Hunter-Killer)",
     "mount": "Main",
     "type": "Nexus",
     "damage": [{
@@ -290,7 +290,7 @@
   },
   {
     "id": "mw_nexus_light",
-    "name": "NEXUS (LIGHT)",
+    "name": "Nexus (Light)",
     "mount": "Auxiliary",
     "type": "Nexus",
     "damage": [{
@@ -311,7 +311,7 @@
   },
   {
     "id": "mw_pistol",
-    "name": "PISTOL",
+    "name": "Pistol",
     "mount": "Auxiliary",
     "type": "CQB",
     "damage": [{
@@ -338,7 +338,7 @@
   },
   {
     "id": "mw_segment_knife",
-    "name": "SEGMENT KNIFE",
+    "name": "Segment Knife",
     "mount": "Auxiliary",
     "type": "Melee",
     "damage": [{
@@ -359,7 +359,7 @@
   },
   {
     "id": "mw_rocket_propelled_grenade",
-    "name": "ROCKET-PROPELLED GRENADE",
+    "name": "Rocket-Propelled Grenade",
     "mount": "Main",
     "type": "Launcher",
     "damage": [{
@@ -389,7 +389,7 @@
   },
   {
     "id": "mw_shotgun",
-    "name": "SHOTGUN",
+    "name": "Shotgun",
     "mount": "Main",
     "type": "CQB",
     "damage": [{
@@ -412,7 +412,7 @@
   },
   {
     "id": "mw_tactical_knife",
-    "name": "TACTICAL KNIFE",
+    "name": "Tactical Knife",
     "mount": "Auxiliary",
     "type": "Melee",
     "damage": [{
@@ -434,7 +434,7 @@
   },
   {
     "id": "mw_tactical_melee_weapon",
-    "name": "TACTICAL MELEE WEAPON",
+    "name": "Tactical Melee Weapon",
     "mount": "Main",
     "type": "Melee",
     "damage": [{
@@ -452,7 +452,7 @@
   },
   {
     "id": "mw_thermal_lance",
-    "name": "THERMAL LANCE",
+    "name": "Thermal Lance",
     "mount": "Heavy",
     "type": "Cannon",
     "damage": [{
@@ -474,7 +474,7 @@
   },
   {
     "id": "mw_thermal_pistol",
-    "name": "THERMAL PISTOL",
+    "name": "Thermal Pistol",
     "mount": "Auxiliary",
     "type": "CQB",
     "damage": [{
@@ -492,7 +492,7 @@
   },
   {
     "id": "mw_thermal_rifle",
-    "name": "THERMAL RIFLE",
+    "name": "Thermal Rifle",
     "mount": "Main",
     "type": "Rifle",
     "damage": [{
@@ -513,7 +513,7 @@
   },
   {
     "id": "mw_chain_axe",
-    "name": "CHAIN AXE",
+    "name": "Chain Axe",
     "mount": "Main",
     "type": "Melee",
     "damage": [{
@@ -536,7 +536,7 @@
   },
   {
     "id": "mw_bristlecrown_flechette_launcher",
-    "name": "BRISTLECROWN FLECHETTE LAUNCHER",
+    "name": "Bristlecrown Flechette Launcher",
     "mount": "Auxiliary",
     "type": "CQB",
     "damage": [{
@@ -555,7 +555,7 @@
   },
   {
     "id": "mw_nanocarbon_sword",
-    "name": "NANOCARBON SWORD",
+    "name": "Nanocarbon Sword",
     "mount": "Heavy",
     "type": "Melee",
     "damage": [{
@@ -577,7 +577,7 @@
   },
   {
     "id": "mw_assault_cannon",
-    "name": "ASSAULT CANNON",
+    "name": "Assault Cannon",
     "mount": "Main",
     "type": "Cannon",
     "source": "IPS-N",
@@ -640,7 +640,7 @@
   },
   {
     "id": "mw_concussion_missiles",
-    "name": "CONCUSSION MISSILES",
+    "name": "Concussion Missiles",
     "mount": "Main",
     "type": "Launcher",
     "damage": [{
@@ -663,7 +663,7 @@
   },
   {
     "id": "mw_leviathan_heavy_assault_cannon",
-    "name": "LEVIATHAN HEAVY ASSAULT CANNON",
+    "name": "Leviathan Heavy Assault Cannon",
     "mount": "Superheavy",
     "type": "Cannon",
     "source": "IPS-N",
@@ -716,7 +716,7 @@
   },
   {
     "id": "mw_cutter_mkii_plasma_torch",
-    "name": "CUTTER MKII PLASMA TORCH",
+    "name": "Cutter MkII Plasma Torch",
     "mount": "Auxiliary",
     "type": "Melee",
     "damage": [{
@@ -748,7 +748,7 @@
   },
   {
     "id": "mw_war_pike",
-    "name": "WAR PIKE",
+    "name": "War Pike",
     "mount": "Main",
     "type": "Melee",
     "damage": [{
@@ -775,7 +775,7 @@
   },
   {
     "id": "mw_power_knuckles",
-    "name": "POWER KNUCKLES",
+    "name": "Power Knuckles",
     "mount": "Auxiliary",
     "type": "Melee",
     "damage": [{
@@ -794,7 +794,7 @@
   },
   {
     "id": "mw_hand_cannon",
-    "name": "HAND CANNON",
+    "name": "Hand Cannon",
     "mount": "Auxiliary",
     "type": "CQB",
     "damage": [{
@@ -825,7 +825,7 @@
   },
   {
     "id": "mw_bolt_thrower",
-    "name": "BOLT THROWER",
+    "name": "Bolt Thrower",
     "mount": "Heavy",
     "type": "Cannon",
     "damage": [{
@@ -856,7 +856,7 @@
   },
   {
     "id": "mw_kinetic_hammer",
-    "name": "KINETIC HAMMER",
+    "name": "Kinetic Hammer",
     "mount": "Heavy",
     "type": "Melee",
     "damage": [{
@@ -878,7 +878,7 @@
   },
   {
     "id": "mw_deck_sweeper_automatic_shotgun",
-    "name": "DECK-SWEEPER AUTOMATIC SHOTGUN",
+    "name": "Deck-Sweeper Automatic Shotgun",
     "mount": "Main",
     "type": "CQB",
     "damage": [{
@@ -904,7 +904,7 @@
   },
   {
     "id": "mw_daisy_cutter",
-    "name": "DAISY CUTTER",
+    "name": "Daisy Cutter",
     "mount": "Heavy",
     "type": "CQB",
     "damage": [{
@@ -927,7 +927,7 @@
   },
   {
     "id": "mw_catalytic_hammer",
-    "name": "CATALYTIC HAMMER",
+    "name": "Catalytic Hammer",
     "mount": "Main",
     "type": "Melee",
     "damage": [{
@@ -949,7 +949,7 @@
   },
   {
     "id": "mw_impact_lance",
-    "name": "IMPACT LANCE",
+    "name": "Impact Lance",
     "mount": "Main",
     "type": "Melee",
     "damage": [{
@@ -968,7 +968,7 @@
   },
   {
     "id": "mw_impaler_nailgun",
-    "name": "IMPALER NAILGUN",
+    "name": "Impaler Nailgun",
     "mount": "Main",
     "type": "CQB",
     "damage": [{
@@ -996,7 +996,7 @@
   },
   {
     "id": "mw_combat_drill",
-    "name": "COMBAT DRILL",
+    "name": "Combat Drill",
     "mount": "Superheavy",
     "type": "Melee",
     "damage": [{
@@ -1027,7 +1027,7 @@
   },
   {
     "id": "mw_magnetic_cannon",
-    "name": "MAGNETIC CANNON",
+    "name": "Magnetic Cannon",
     "mount": "Main",
     "type": "Cannon",
     "damage": [{
@@ -1046,7 +1046,7 @@
   },
   {
     "id": "mw_vulture_dmr",
-    "name": "VULTURE DMR",
+    "name": "Vulture DMR",
     "mount": "Main",
     "type": "Rifle",
     "damage": [{
@@ -1075,7 +1075,7 @@
   },
   {
     "id": "mw_railgun",
-    "name": "RAILGUN",
+    "name": "Railgun",
     "mount": "Heavy",
     "type": "Rifle",
     "damage": [{
@@ -1104,7 +1104,7 @@
   },
   {
     "id": "mw_veil_rifle",
-    "name": "VEIL RIFLE",
+    "name": "Veil Rifle",
     "mount": "Main",
     "type": "Rifle",
     "damage": [{
@@ -1126,7 +1126,7 @@
   },
   {
     "id": "mw_burst_launcher",
-    "name": "BURST LAUNCHER",
+    "name": "Burst Launcher",
     "mount": "Main",
     "type": "Launcher",
     "damage": [{
@@ -1157,7 +1157,7 @@
   },
   {
     "id": "mw_rail_rifle",
-    "name": "RAIL RIFLE",
+    "name": "Rail Rifle",
     "mount": "Main",
     "type": "Rifle",
     "damage": [{
@@ -1179,7 +1179,7 @@
   },
   {
     "id": "mw_shock_knife",
-    "name": "SHOCK KNIFE",
+    "name": "Shock Knife",
     "mount": "Auxiliary",
     "type": "Melee",
     "damage": [{
@@ -1211,7 +1211,7 @@
   },
   {
     "id": "mw_sharanga_missiles",
-    "name": "SHARANGA MISSILES",
+    "name": "Sharanga Missiles",
     "mount": "Main",
     "type": "Launcher",
     "damage": [{
@@ -1233,7 +1233,7 @@
   },
   {
     "id": "mw_gandiva_missiles",
-    "name": "GANDIVA MISSILES",
+    "name": "Gandiva Missiles",
     "mount": "Heavy",
     "type": "Launcher",
     "damage": [{
@@ -1262,7 +1262,7 @@
   },
   {
     "id": "mw_pinaka_missiles",
-    "name": "PINAKA MISSILES",
+    "name": "Pinaka Missiles",
     "mount": "Superheavy",
     "type": "Launcher",
     "damage": [{
@@ -1294,7 +1294,7 @@
   },
   {
     "id": "mw_fold_knife",
-    "name": "FOLD KNIFE",
+    "name": "Fold Knife",
     "mount": "Auxiliary",
     "type": "Melee",
     "damage": [{
@@ -1316,7 +1316,7 @@
   },
   {
     "id": "mw_vijaya_rockets",
-    "name": "VIJAYA ROCKETS",
+    "name": "Vijaya Rockets",
     "mount": "Auxiliary",
     "type": "Launcher",
     "damage": [{
@@ -1337,7 +1337,7 @@
   },
   {
     "id": "mw_variable_sword",
-    "name": "VARIABLE SWORD",
+    "name": "Variable Sword",
     "mount": "Main",
     "type": "Melee",
     "damage": [{
@@ -1359,7 +1359,7 @@
   },
   {
     "id": "mw_oracle_lmg_i",
-    "name": "ORACLE LMG-I",
+    "name": "Oracle LMG-I",
     "mount": "Auxiliary",
     "type": "Rifle",
     "damage": [{
@@ -1385,7 +1385,7 @@
   },
   {
     "id": "mw_nanobot_whip",
-    "name": "NANOBOT WHIP",
+    "name": "Nanobot Whip",
     "mount": "Heavy",
     "type": "Melee",
     "damage": [{
@@ -1408,7 +1408,7 @@
   },
   {
     "id": "mw_swarm_hive_nanites",
-    "name": "SWARM/HIVE NANITES",
+    "name": "Swarm/Hive Nanites",
     "mount": "Main",
     "type": "Nexus",
     "damage": [{
@@ -1438,7 +1438,7 @@
   },
   {
     "id": "mw_autopod",
-    "name": "AUTOPOD",
+    "name": "Autopod",
     "mount": "Main",
     "type": "Launcher",
     "no_attack": true,
@@ -1473,7 +1473,7 @@
   },
   {
     "id": "mw_vorpal_gun",
-    "name": "VORPAL GUN",
+    "name": "Vorpal Gun",
     "mount": "Main",
     "type": "Cannon",
     "no_attack": true,
@@ -1500,7 +1500,7 @@
   },
   {
     "id": "mw_ghoul_nexus",
-    "name": "GHOUL NEXUS",
+    "name": "Ghoul Nexus",
     "mount": "Main",
     "type": "Nexus",
     "damage": [{
@@ -1526,7 +1526,7 @@
   },
   {
     "id": "mw_ghast_nexus",
-    "name": "GHAST NEXUS",
+    "name": "Ghast Nexus",
     "mount": "Heavy",
     "type": "Nexus",
     "damage": [{
@@ -1563,7 +1563,7 @@
   },
   {
     "id": "mw_annihilation_nexus",
-    "name": "ANNIHILATION NEXUS",
+    "name": "Annihilation Nexus",
     "mount": "Superheavy",
     "type": "Nexus",
     "damage": [{
@@ -1596,7 +1596,7 @@
   },
   {
     "id": "mw_catalyst_pistol",
-    "name": "CATALYST PISTOL",
+    "name": "Catalyst Pistol",
     "mount": "Auxiliary",
     "type": "CQB",
     "damage": [{
@@ -1623,7 +1623,7 @@
   },
   {
     "id": "mw_arc_projector",
-    "name": "ARC PROJECTOR",
+    "name": "Arc Projector",
     "mount": "Heavy",
     "type": "CQB",
     "damage": [{
@@ -1646,7 +1646,7 @@
   },
   {
     "id": "mw_smartgun",
-    "name": "SMARTGUN",
+    "name": "Smartgun",
     "mount": "Main",
     "type": "Rifle",
     "damage": [{
@@ -1675,7 +1675,7 @@
   },
   {
     "id": "mw_mimic_gun",
-    "name": "MIMIC GUN",
+    "name": "Mimic Gun",
     "mount": "Heavy",
     "type": "???",
     "no_mods": true,
@@ -1705,7 +1705,7 @@
   },
   {
     "id": "mw_autogun",
-    "name": "AUTOGUN",
+    "name": "Autogun",
     "mount": "Main",
     "type": "Cannon",
     "no_attack": true,
@@ -1734,7 +1734,7 @@
   },
   {
     "id": "mw_siege_cannon",
-    "name": "SIEGE CANNON",
+    "name": "Siege Cannon",
     "mount": "Superheavy",
     "type": "Cannon",
     "source": "HA",
@@ -1795,7 +1795,7 @@
   },
   {
     "id": "mw_krakatoa_thermobaric_flamethrower",
-    "name": "KRAKATOA THERMOBARIC FLAMETHROWER",
+    "name": "Krakatoa Thermobaric Flamethrower",
     "mount": "Heavy",
     "type": "CQB",
     "damage": [{
@@ -1818,7 +1818,7 @@
   },
   {
     "id": "mw_plasma_thrower",
-    "name": "PLASMA THROWER",
+    "name": "Plasma Thrower",
     "mount": "Superheavy",
     "type": "CQB",
     "damage": [{
@@ -1852,7 +1852,7 @@
   },
   {
     "id": "mw_stub_cannon",
-    "name": "STUB CANNON",
+    "name": "Stub Cannon",
     "mount": "Auxiliary",
     "type": "Cannon",
     "damage": [{
@@ -1879,7 +1879,7 @@
   },
   {
     "id": "mw_gravity_gun",
-    "name": "GRAVITY GUN",
+    "name": "Gravity Gun",
     "no_mods": true,
     "no_core_bonus": true,
     "mount": "Heavy",
@@ -1902,7 +1902,7 @@
   },
   {
     "id": "mw_displacer",
-    "name": "DISPLACER",
+    "name": "Displacer",
     "mount": "Main",
     "type": "Rifle",
     "damage": [{
@@ -1939,7 +1939,7 @@
   },
   {
     "id": "mw_shatterhead_colony_missiles",
-    "name": "SHATTERHEAD COLONY MISSILES",
+    "name": "Shatterhead Colony Missiles",
     "mount": "Main",
     "type": "Launcher",
     "damage": [{
@@ -1962,7 +1962,7 @@
   },
   {
     "id": "mw_sol_pattern_laser_rifle",
-    "name": "SOL-PATTERN LASER RIFLE",
+    "name": "SOL-Pattern Laser Rifle",
     "mount": "Main",
     "type": "Rifle",
     "damage": [{
@@ -1989,7 +1989,7 @@
   },
   {
     "id": "mw_andromeda_pattern_heavy_laser_rifle",
-    "name": "ANDROMEDA-PATTERN HEAVY LASER RIFLE",
+    "name": "ANDROMEDA-Pattern Heavy Laser Rifle",
     "mount": "Heavy",
     "type": "Cannon",
     "damage": [{
@@ -2016,7 +2016,7 @@
   },
   {
     "id": "mw_tachyon_lance",
-    "name": "TACHYON LANCE",
+    "name": "Tachyon Lance",
     "mount": "Superheavy",
     "type": "Cannon",
     "damage": [{
@@ -2048,7 +2048,7 @@
   },
   {
     "id": "mw_annihilator",
-    "name": "ANNIHILATOR",
+    "name": "Annihilator",
     "mount": "Main",
     "type": "CQB",
     "damage": [{
@@ -2080,7 +2080,7 @@
   },
   {
     "id": "mw_torch",
-    "name": "TORCH",
+    "name": "Torch",
     "mount": "Main",
     "type": "Melee",
     "damage": [{


### PR DESCRIPTION
Primarily changing things from upper case to formatted case. I went through the book to ensure every name matched exactly. Someone should probably do a quick sanity check. The purpose of this is to better support using `name` in contexts like the middle of other text, or closer copies to the way the books formats things.

To get the old style one can use:
- (js) `name.toUpperCase()`
- (css) `text-transform: upper-case;`