### PR TITLE
feat(data): add license_id to tie mechequipment to license

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ FACTIONS are an upcoming feature that is not yet implemented within COMP/CON. Th
 {
   "id": string,
   "license_level": number, // set to zero for this item to be available to a LL0 character
+  "license_id": string, // reference to the Frame id of the associated license, relevant for variants
+  "variant": string, // optional; name of the main frame license for which this frame is a variant
   "source": string, // must be the same as the Manufacturer ID to sort correctly
   "name": string,
   "mechtype": string[], // can be customized
@@ -333,6 +335,7 @@ Weapon mods are handled separately in C/C than in Lancer (where they're just tag
   "name": string,
   "source": string, // Manufacturer ID
   "license": string, // Frame Name
+  "license_id": string, // reference to the Frame id of the associated license
   "license_level": number, // set to 0 to be available to all Pilots
   "sp"?: number,
   "description"?: string, // v-html
@@ -514,6 +517,7 @@ The rules file sets some of the base values of the game, but as of this writing 
     "name": string,
     "source": string, // must be the same as the Manufacturer ID to sort correctly
     "license": string, // reference to the Frame name of the associated license
+    "license_id": string, // reference to the Frame id of the associated license
     "license_level": number, // set to zero for this item to be available to a LL0 character
     "effect"?: string, // v-html
     "type"?: SystemType
@@ -642,6 +646,7 @@ Weapons are essentially mounted systems that furnish the "Skirmish" and "Barrage
   "name": string,
   "source": string, // must be the same as the Manufacturer ID to sort correctly
   "license": string, // reference to the Frame name of the associated license
+  "license_id": string, // reference to the Frame id of the associated license
   "license_level": number, // set to zero for this item to be available to a LL0 character
   "mount": MountType,
   "type": WeaponType,

--- a/lib/frames.json
+++ b/lib/frames.json
@@ -34,7 +34,8 @@
       "use": "Next Round",
       "activation": "Free"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/missing_frame.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/missing_frame.png",
+    "license_id": "missing_frame"
   },
   {
     "id": "mf_standard_pattern_i_everest",
@@ -139,7 +140,8 @@
         "src": "pre_vanguard_pixel.png"
       }
     ],
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_standard_pattern_i_everest.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_standard_pattern_i_everest.png",
+    "license_id": "mf_standard_pattern_i_everest"
   },
   {
     "id": "mf_blackbeard",
@@ -219,7 +221,8 @@
       "active_effect": "This system fires grappling harpoons at any number of targets within Range 5 and line of sight. Affected characters must succeed on a Hull save or take 2d6 Kinetic damage and be knocked Prone, then pulled adjacent to you, or as close as possible. They become Immobilized until the end of their next turn. On a success, they take half damage and are otherwise unaffected.",
       "activation": "Quick"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_blackbeard.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_blackbeard.png",
+    "license_id": "mf_blackbeard"
   },
   {
     "id": "mf_drake",
@@ -287,7 +290,8 @@
       "deactivation": "Protocol",
       "activation": "Protocol"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_drake.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_drake.png",
+    "license_id": "mf_drake"
   },
   {
     "id": "mf_lancaster",
@@ -349,7 +353,8 @@
         "mw_lancaster_integrated"
       ]
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_lancaster.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_lancaster.png",
+    "license_id": "mf_lancaster"
   },
   {
     "id": "mf_nelson",
@@ -407,7 +412,8 @@
       "use": "Encounter",
       "activation": "Protocol"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_nelson.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_nelson.png",
+    "license_id": "mf_nelson"
   },
   {
     "id": "mf_raleigh",
@@ -461,7 +467,8 @@
         "mw_raleigh_integrated"
       ]
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_raleigh.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_raleigh.png",
+    "license_id": "mf_raleigh"
   },
   {
     "id": "mf_tortuga",
@@ -518,7 +525,8 @@
         "src": "alt_hortuga.png"
       }
     ],
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_tortuga.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_tortuga.png",
+    "license_id": "mf_tortuga"
   },
   {
     "id": "mf_vlad",
@@ -577,7 +585,8 @@
         "src": "alt_agonist.png"
       }
     ],
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_vlad.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_vlad.png",
+    "license_id": "mf_vlad"
   },
   {
     "id": "mf_black_witch",
@@ -636,7 +645,8 @@
       "activation": "Full",
       "use": "Next Turn"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_black_witch.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_black_witch.png",
+    "license_id": "mf_black_witch"
   },
   {
     "id": "mf_deaths_head",
@@ -723,7 +733,8 @@
         "src": "alt_hercules.png"
       }
     ],
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_deaths_head.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_deaths_head.png",
+    "license_id": "mf_deaths_head"
   },
   {
     "id": "mf_dusk_wing",
@@ -810,7 +821,8 @@
       "use": "Encounter",
       "activation": "Protocol"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_dusk_wing.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_dusk_wing.png",
+    "license_id": "mf_dusk_wing"
   },
   {
     "id": "mf_metalmark",
@@ -869,7 +881,8 @@
       "use": "Encounter",
       "activation": "Protocol"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_metalmark.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_metalmark.png",
+    "license_id": "mf_metalmark"
   },
   {
     "id": "mf_monarch",
@@ -951,7 +964,8 @@
       "active_effect": "Choose any number of characters within range 50: your targets must each succeed on an Agility save or take 1d6+4 explosive. On a success, they take half damage. These self-guiding missiles can reach any target as long as there is a path to do so.",
       "activation": "Full"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_monarch.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_monarch.png",
+    "license_id": "mf_monarch"
   },
   {
     "id": "mf_mourning_cloak",
@@ -1033,7 +1047,8 @@
         }
       ]
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_mourning_cloak.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_mourning_cloak.png",
+    "license_id": "mf_mourning_cloak"
   },
   {
     "id": "mf_swallowtail",
@@ -1101,7 +1116,8 @@
       "use": "Encounter",
       "activation": "Protocol"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_swallowtail.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_swallowtail.png",
+    "license_id": "mf_swallowtail"
   },
   {
     "id": "mf_balor",
@@ -1156,7 +1172,8 @@
       "use": "Encounter",
       "activation": "Protocol"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_balor.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_balor.png",
+    "license_id": "mf_balor"
   },
   {
     "id": "mf_goblin",
@@ -1237,7 +1254,8 @@
       "deactivation": "Quick",
       "use": "Encounter"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_goblin.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_goblin.png",
+    "license_id": "mf_goblin"
   },
   {
     "id": "mf_gorgon",
@@ -1292,7 +1310,8 @@
       "activation": "Quick",
       "use": "Encounter"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_gorgon.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_gorgon.png",
+    "license_id": "mf_gorgon"
   },
   {
     "id": "mf_hydra",
@@ -1396,7 +1415,8 @@
       ],
       "passive_effect": "Your mech contains powerful, integrated drone companions. At creation, choose a single OROCHI Drone to accompany you. <br>Your OROCHI drones share your Evasion, E-Defense, and Speed. They can move independently on your turn, but can’t take any other actions. If you can fly or teleport, they can too.<br>If an OROCHI drone is within Sensors, you may recall it as a quick action, integrating it into your mech’s body where it cannot be targeted. You may redeploy it to a space within Sensors as a quick action. <br>When you rest or perform a FULL REPAIR, you may choose a different drone to accompany you; additionally, your drones regain all HP and are automatically repaired if they were destroyed."
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_hydra.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_hydra.png",
+    "license_id": "mf_hydra"
   },
   {
     "id": "mf_manticore",
@@ -1462,7 +1482,8 @@
         "max": 6
       }
     ],
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_manticore.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_manticore.png",
+    "license_id": "mf_manticore"
   },
   {
     "id": "mf_minotaur",
@@ -1523,7 +1544,8 @@
         }
       ]
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_minotaur.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_minotaur.png",
+    "license_id": "mf_minotaur"
   },
   {
     "id": "mf_pegasus",
@@ -1583,7 +1605,8 @@
         }
       ]
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_pegasus.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_pegasus.png",
+    "license_id": "mf_pegasus"
   },
   {
     "id": "mf_barbarossa",
@@ -1662,7 +1685,8 @@
         "max": 4
       }
     ],
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_barbarossa.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_barbarossa.png",
+    "license_id": "mf_barbarossa"
   },
   {
     "id": "mf_genghis",
@@ -1712,7 +1736,8 @@
       "active_effect": "The next time you exceed your Heat Cap this scene, you instead clear all heat and vent a burst 3 cloud of burning matter from your mech.<br>Until the start of your next turn, all characters within the affected area count as Invisible to everyone except you, and characters other than you take 2 burn and 2 heat when they start their turn in the area or enter it for the first time in a round. Once this effect ends, characters within the affected area receive soft cover (which you ignore) until the start of your following turn, at which point the cloud disperses.",
       "activation": "Quick"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_genghis.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_genghis.png",
+    "license_id": "mf_genghis"
   },
   {
     "id": "mf_iskander",
@@ -1768,7 +1793,8 @@
       "use": "Encounter",
       "activation": "Quick"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_iskander.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_iskander.png",
+    "license_id": "mf_iskander"
   },
   {
     "id": "mf_napoleon",
@@ -1826,7 +1852,8 @@
       "use": "Encounter",
       "activation": "Quick"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_napoleon.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_napoleon.png",
+    "license_id": "mf_napoleon"
   },
   {
     "id": "mf_saladin",
@@ -1894,7 +1921,8 @@
       ],
       "activation": "Quick"
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_saladin.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_saladin.png",
+    "license_id": "mf_saladin"
   },
   {
     "id": "mf_sherman",
@@ -1977,7 +2005,8 @@
         "max": 4
       }
     ],
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_sherman.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_sherman.png",
+    "license_id": "mf_sherman"
   },
   {
     "id": "mf_tokugawa",
@@ -2074,6 +2103,7 @@
         }
       ]
     },
-    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_tokugawa.png"
+    "image_url": "https://compcon-image-assets.s3.amazonaws.com/frames/mf_tokugawa.png",
+    "license_id": "mf_tokugawa"
   }
 ]

--- a/lib/mods.json
+++ b/lib/mods.json
@@ -11,7 +11,8 @@
     "license_level": 1,
     "effect": "COMP/CON is unable to retrieve the data necessary to furnish this System. This is likely the result of a missing or outdated content pack.",
     "description": "COMP/CON is unable to retrieve the data necessary to furnish this System. This is likely the result of a missing or outdated content pack.",
-    "tags": []
+    "tags": [],
+    "license_id": ""
   },
   {
     "id": "wm_thermal_charge",
@@ -39,7 +40,8 @@
         "type": "Explosive",
         "val": "1d6"
       }
-    ]
+    ],
+    "license_id": "mf_nelson"
   },
   {
     "id": "wm_uncle_class_comp_con",
@@ -71,7 +73,8 @@
     ],
     "restricted_sizes": [
       "Superheavy"
-    ]
+    ],
+    "license_id": "mf_raleigh"
   },
   {
     "id": "wm_throughbolt_rounds",
@@ -91,7 +94,8 @@
       {
         "id": "tg_unique"
       }
-    ]
+    ],
+    "license_id": "mf_tortuga"
   },
   {
     "id": "wm_shock_wreath",
@@ -116,7 +120,8 @@
       {
         "id": "tg_unique"
       }
-    ]
+    ],
+    "license_id": "mf_metalmark"
   },
   {
     "id": "wm_stabilizer_mod",
@@ -141,7 +146,8 @@
       {
         "id": "tg_ordnance"
       }
-    ]
+    ],
+    "license_id": "mf_monarch"
   },
   {
     "id": "wm_nanocomposite_adaptation",
@@ -167,7 +173,8 @@
       {
         "id": "tg_seeking"
       }
-    ]
+    ],
+    "license_id": "mf_balor"
   },
   {
     "id": "wm_phase_ready_mod",
@@ -185,7 +192,8 @@
     "license": "NAPOLEON",
     "license_level": 2,
     "effect": "As long as you know the rough location of your target, the weapon this mod is applied to can attack through solid walls and obstructions, doesn’t require line of sight, and ignores all cover, but targets attacked this way count as Invisible.",
-    "description": "As it was named following its first use during the civil hostilities on Luna de Oro, phase-ready ammunition is the “devil’s bullets”. Each round contains a nanoprocessor suite networked with its weapon of origin that calculates and translates the specific nature of that round’s superpositional relation with a projected future doppelgänger that manifests in the space immediately before its intended target. To put it simply, phase-ready rounds, when fired, exist in two places at once: exiting the barrel of the weapon they were fired from, and directly in front of the target, prior to impact. The prime round may never hit its target, but given it already exists at the moment of impact, the doppelgänger round will reliably reach its mark."
+    "description": "As it was named following its first use during the civil hostilities on Luna de Oro, phase-ready ammunition is the “devil’s bullets”. Each round contains a nanoprocessor suite networked with its weapon of origin that calculates and translates the specific nature of that round’s superpositional relation with a projected future doppelgänger that manifests in the space immediately before its intended target. To put it simply, phase-ready rounds, when fired, exist in two places at once: exiting the barrel of the weapon they were fired from, and directly in front of the target, prior to impact. The prime round may never hit its target, but given it already exists at the moment of impact, the doppelgänger round will reliably reach its mark.",
+    "license_id": "mf_napoleon"
   },
   {
     "id": "wm_paracausal_mod",
@@ -208,6 +216,7 @@
       {
         "id": "tg_overkill"
       }
-    ]
+    ],
+    "license_id": "mf_saladin"
   }
 ]

--- a/lib/systems.json
+++ b/lib/systems.json
@@ -8,7 +8,8 @@
     "license_level": 0,
     "effect": "COMP/CON is unable to retrieve the data necessary to furnish this System. This is likely the result of a missing or outdated content pack.",
     "description": "COMP/CON is unable to retrieve the data necessary to furnish this System. This is likely the result of a missing or outdated content pack.",
-    "tags": []
+    "tags": [],
+    "license_id": ""
   },
   {
     "id": "ms_comp_con_class_assistant_unit",
@@ -30,7 +31,8 @@
     "license": "GMS",
     "license_level": 0,
     "effect": "Your mech has a basic comp/con unit, granting it the AI tag. The comp/con can speak to you and has a personality, but, unlike an NHP, is not truly capable of independent thought. It is obedient to you alone.<br>You can give control of your mech to its comp/con as a protocol, allowing your mech to act independently on your turn with its own set of actions. Unlike other AIs, a mech controlled by a comp/con has no independent initiative and requires direct input. Your mech will follow basic courses of action (defend this area, attack this enemy, protect me, etc.) to the best of its ability, or will act to defend itself if its instructions are complete or it receives no further guidance. You can issue new commands at the start of your turn as long as you are within Range 50 and have the means to communicate with your mech. Comp/con units are not true NHPs and thus cannot enter cascade.",
-    "description": "The GMS Companion/Concierge-Class Assistant Unit conforms to all galaxy-wide standards. These virtual assistants pass even the most rigid Turing-Null assessment criteria and are cleared to operate even in the absence of a pilot."
+    "description": "The GMS Companion/Concierge-Class Assistant Unit conforms to all galaxy-wide standards. These virtual assistants pass even the most rigid Turing-Null assessment criteria and are cleared to operate even in the absence of a pilot.",
+    "license_id": ""
   },
   {
     "id": "ms_custom_paint_job",
@@ -47,7 +49,8 @@
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "effect": "When you take structure damage, roll 1d6. On a 6, you return to 1 HP and ignore the damage – the hit simply ‘scratched your paint’.<br>This system can only be used once before each Full Repair, and is not a valid target for system destruction."
+    "effect": "When you take structure damage, roll 1d6. On a 6, you return to 1 HP and ignore the damage – the hit simply ‘scratched your paint’.<br>This system can only be used once before each Full Repair, and is not a valid target for system destruction.",
+    "license_id": ""
   },
   {
     "id": "ms_expanded_compartment",
@@ -61,7 +64,8 @@
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "effect": "Your mech has space for one additional non-Mech character or object of Size 1/2 to ride as a passenger in the cockpit. While inside the mech, they cannot suffer any effect from outside or be targeted by attacks, as if they were a pilot. You can hand over or take back control to or from them as a protocol (following the same rules as pilot and AIs), but if they take over the controls from you, the mech becomes Impaired and Slowed to reflect the lack of appropriate licenses and integration."
+    "effect": "Your mech has space for one additional non-Mech character or object of Size 1/2 to ride as a passenger in the cockpit. While inside the mech, they cannot suffer any effect from outside or be targeted by attacks, as if they were a pilot. You can hand over or take back control to or from them as a protocol (following the same rules as pilot and AIs), but if they take over the controls from you, the mech becomes Impaired and Slowed to reflect the lack of appropriate licenses and integration.",
+    "license_id": ""
   },
   {
     "id": "ms_manipulators",
@@ -76,7 +80,8 @@
     "license": "GMS",
     "license_level": 0,
     "effect": "Your mech has an extra set of limbs. They are too small to have any combat benefit, but allow the mech to interact with objects that would otherwise be too small or sensitive (e.g., pilot-sized touch pads).",
-    "description": "Precise interaction with built and natural environments, soft targets, and hazardous materials is part of the daily routine for support-class mechs. This is made possible by manipulators – added multi-digit “hands” with haptic sensors."
+    "description": "Precise interaction with built and natural environments, soft targets, and hazardous materials is part of the daily routine for support-class mechs. This is made possible by manipulators – added multi-digit “hands” with haptic sensors.",
+    "license_id": ""
   },
   {
     "id": "ms_pattern_a_smoke_charges",
@@ -127,7 +132,8 @@
         ],
         "detail": "This mine detonates when any allied character moves over or adjacent to it. All characters and objects within a Burst 3 area benefit from soft cover until the end of the detonating character’s next turn, at which point the smoke disperses."
       }
-    ]
+    ],
+    "license_id": ""
   },
   {
     "id": "ms_pattern_a_jericho_deployable_cover",
@@ -154,7 +160,8 @@
         "recall": "Full",
         "redeploy": "Quick"
       }
-    ]
+    ],
+    "license_id": ""
   },
   {
     "id": "ms_pattern_b_hex_charges",
@@ -212,7 +219,8 @@
         "activation": "Quick",
         "detail": "All characters within a Burst 1 area must pass an Agility save or take 2d6 Explosive damage. On a success, they take half damage."
       }
-    ]
+    ],
+    "license_id": ""
   },
   {
     "id": "ms_personalizations",
@@ -232,7 +240,8 @@
         "id": "hp",
         "val": 2
       }
-    ]
+    ],
+    "license_id": ""
   },
   {
     "id": "ms_stable_structure",
@@ -246,7 +255,8 @@
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "effect": "You gain +1 Accuracy on saves to avoid Prone or Knockback."
+    "effect": "You gain +1 Accuracy on saves to avoid Prone or Knockback.",
+    "license_id": ""
   },
   {
     "id": "ms_turret_drones",
@@ -286,7 +296,8 @@
         ]
       }
     ],
-    "description": "The use of turret drones is a rather traditional form of force multiplication – one that has remained the backbone of defense in many theaters."
+    "description": "The use of turret drones is a rather traditional form of force multiplication – one that has remained the backbone of defense in many theaters.",
+    "license_id": ""
   },
   {
     "id": "ms_type_3_projected_shield",
@@ -315,7 +326,8 @@
         "detail": "Nominate a character within line of sight: all ranged or melee attacks that they make against you or that you make against them gain +2 Difficulty until the start of your next turn."
       }
     ],
-    "description": "The GMS Type-3 Projected Shield traps and denies incoming projectiles by projecting an aggressive, superpositional anti-ballistic barrier."
+    "description": "The GMS Type-3 Projected Shield traps and denies incoming projectiles by projecting an aggressive, superpositional anti-ballistic barrier.",
+    "license_id": ""
   },
   {
     "id": "ms_eva_module",
@@ -338,7 +350,8 @@
         ],
         "detail": "Your mech has a propulsion system suitable for use in low or zero gravity and underwater environments. In those environments, you can fly and are not Slowed."
       }
-    ]
+    ],
+    "license_id": ""
   },
   {
     "id": "ms_rapid_burst_jump_jet_system",
@@ -361,7 +374,8 @@
         ],
         "detail": "You can fly when you Boost; however, you must end the movement on the ground or another solid surface, or else immediately begin falling."
       }
-    ]
+    ],
+    "license_id": ""
   },
   {
     "id": "ms_type_i_flight_system",
@@ -384,7 +398,8 @@
         ],
         "detail": "You can fly when you Boost; however, you must end the movement on the ground or another solid surface, or else immediately begin falling."
       }
-    ]
+    ],
+    "license_id": ""
   },
   {
     "id": "ms_synthetic_muscle_netting",
@@ -413,7 +428,8 @@
         "detail": "When you Grapple larger targets, you count as the same Size as the largest opponent. When you Grapple opponents of the same Size or smaller, you count as at least one Size larger."
       }
     ],
-    "description": "IPS-N’s Synthetic Muscle Netting (SMN) is a proprietary, field-proven modification compatible with all existing IPS-N frames. This convenient spray-on catalytic and structural enhancement boosts manipulator and propulsion performance by roughly 25 percent with no demonstrated reduction in operational life. An SMN layer also enhances impact absorption and thermal insulation.<br>IPS-N recommends that pilots apply SMN to internal components only and practice frequent cleaning to prevent septic-analogous decay."
+    "description": "IPS-N’s Synthetic Muscle Netting (SMN) is a proprietary, field-proven modification compatible with all existing IPS-N frames. This convenient spray-on catalytic and structural enhancement boosts manipulator and propulsion performance by roughly 25 percent with no demonstrated reduction in operational life. An SMN layer also enhances impact absorption and thermal insulation.<br>IPS-N recommends that pilots apply SMN to internal components only and practice frequent cleaning to prevent septic-analogous decay.",
+    "license_id": "mf_blackbeard"
   },
   {
     "id": "ms_reinforced_cabling",
@@ -434,7 +450,8 @@
         "detail": "Make a contested Hull check against a character within 5 Range and line of sight: the loser is knocked Prone."
       }
     ],
-    "description": "Reinforced grappling cables allow for full movement and utility in ≤1 g environments. Woven from incredibly strong nanocarbon and arachnosynth threading, reinforced grapple line is carried on waist-mounted spools and attached to charge-actuated brachial projectors. Once fired, the grapples penetrate and anchor to the target. Small meltdown charges seeded every thirty meters of cable both allow rapid disengagement and expose a fresh grapple head, ready for immediate use."
+    "description": "Reinforced grappling cables allow for full movement and utility in ≤1 g environments. Woven from incredibly strong nanocarbon and arachnosynth threading, reinforced grapple line is carried on waist-mounted spools and attached to charge-actuated brachial projectors. Once fired, the grapples penetrate and anchor to the target. Small meltdown charges seeded every thirty meters of cable both allow rapid disengagement and expose a fresh grapple head, ready for immediate use.",
+    "license_id": "mf_blackbeard"
   },
   {
     "id": "ms_sekhmet_class_nhp",
@@ -459,7 +476,8 @@
         "detail": "When activated, you give control of your mech to your NHP and gain the following benefits:<ul><li>All melee critical hits deal +1d6 bonus damage.</li><li>1/round, you can Skirmish with melee weapons only as a free action.</li></ul>Your NHP uses all available actions and movement to move toward the closest visible character – allied or hostile – and attacks them with melee attacks, prioritizing melee weapons. It may benefit from your talents. If there are no characters within Threat, your NHP uses all actions to move as directly as possible to the next closest (visible) target. Your NHP can’t make ranged attacks, even if there are actions available.<br>You retain enough control to Overcharge as usual; however, your NHP uses the additional action for the same purpose as its other actions.<br>You can take back control of your mech as a protocol. When you do, you become Stunned until the start of your next turn. Otherwise, this effect lasts until your mech is destroyed – the pilot’s incapacitation or death has no effect."
       }
     ],
-    "description": "“The IPS-N SEKHMET co-pilot is ready to be your first mate! SEKHMET comes standard with remote, omninet, IR tag, and voice control systems, and is fully compatible with all current and legacy IPS-N mechs.<br>Did you know that SEKHMET learns with you? Should the worst happen, your very own SEKHMET will continue to engage hostile targets using an emulated neural-net doppelgänger to pilot your IPS-N chassis until forced or voluntary shutdown!”<br>draft copy, IPS-N Polaris Pilot Lounge adbroad [struck and replaced w/current adbroad]<br>SEKHMET-class NHPs tend toward aggressive attitudes and dark humor. Pilots often call them “berserker systems” – dangerous NHPs that value combat efficacy over pilot wellbeing."
+    "description": "“The IPS-N SEKHMET co-pilot is ready to be your first mate! SEKHMET comes standard with remote, omninet, IR tag, and voice control systems, and is fully compatible with all current and legacy IPS-N mechs.<br>Did you know that SEKHMET learns with you? Should the worst happen, your very own SEKHMET will continue to engage hostile targets using an emulated neural-net doppelgänger to pilot your IPS-N chassis until forced or voluntary shutdown!”<br>draft copy, IPS-N Polaris Pilot Lounge adbroad [struck and replaced w/current adbroad]<br>SEKHMET-class NHPs tend toward aggressive attitudes and dark humor. Pilots often call them “berserker systems” – dangerous NHPs that value combat efficacy over pilot wellbeing.",
+    "license_id": "mf_blackbeard"
   },
   {
     "id": "ms_argonaut_shield",
@@ -479,7 +497,8 @@
         "detail": "You use the heavy overarm Argonaut Shield to provide cover for an adjacent character as a quick action, giving them Resistance to all damage; however, you take half of the damage your target would take before calculating Armor and Resistance. This effect lasts until your target breaks adjacency, at which point this effect ceases until you repeat this action."
       }
     ],
-    "description": "In space, simplicity in form and function guarantees reliability and promotes trust. The Argonaut is one of IPS-N’s oldest designs, hailing from the pre-merger days of Northstar’s Deep Black security teams. It’s a simple slab of metal carried in hand or mounted on a chassis’ brachial superstructure; the only option a pilot has for customizing this shield is a choice of size."
+    "description": "In space, simplicity in form and function guarantees reliability and promotes trust. The Argonaut is one of IPS-N’s oldest designs, hailing from the pre-merger days of Northstar’s Deep Black security teams. It’s a simple slab of metal carried in hand or mounted on a chassis’ brachial superstructure; the only option a pilot has for customizing this shield is a choice of size.",
+    "license_id": "mf_drake"
   },
   {
     "id": "ms_aegis_shield_generator",
@@ -524,7 +543,8 @@
         ]
       }
     ],
-    "description": "The Aegis is a portable electromagnetic shield generator: a powerful and reliable method – if crude by modern standards – for establishing kinetic and coherent-particle deterrence over a wide area."
+    "description": "The Aegis is a portable electromagnetic shield generator: a powerful and reliable method – if crude by modern standards – for establishing kinetic and coherent-particle deterrence over a wide area.",
+    "license_id": "mf_drake"
   },
   {
     "id": "ms_portable_bunker",
@@ -556,7 +576,8 @@
         "detail": "All characters completely within the bunker's 4x4 area gain hard cover against all attacks from outside the bunker from all directions and Resistance to damage from Blast, Line, Burst, and Cone attacks that originate outside the bunker.<br>The bunker is open topped, and characters may enter or exit at will. It can’t be moved or deactivated once deployed."
       }
     ],
-    "description": "IPS-N’s “Portable Bunker” is actually a series of single-use expanding printer sheets: flat-pack pouches of inert non-Newtonian fluid that, when deployed, become a rigid structure capable of withstanding incredible force."
+    "description": "IPS-N’s “Portable Bunker” is actually a series of single-use expanding printer sheets: flat-pack pouches of inert non-Newtonian fluid that, when deployed, become a rigid structure capable of withstanding incredible force.",
+    "license_id": "mf_drake"
   },
   {
     "id": "ms_cable_winch_system",
@@ -571,7 +592,8 @@
         "detail": "These cables can be attached to an adjacent character. If the target is Stunned or willing, you automatically succeed; otherwise, they can resist with a successful Hull save. Once attached, you and the target may not move more than 5 spaces away from each other. Either character can tow the other, obeying the normal rules for lifting and dragging, and becoming Slowed while doing so.<br>Any character can remove the cables on a hit with a melee attack or Improvised Attack against Evasion 10.<br>These cables can also be used to drag, pull, or otherwise interact with objects and the environment. They are 5 spaces long and can support a combined Size 6 before they break. Characters can use them to climb surfaces, allowing them to climb without a Speed penalty."
       }
     ],
-    "description": "A winch system consists of an externally mounted spool of nanocarbon-weave cable and a recovery subroutine installed on the mech."
+    "description": "A winch system consists of an externally mounted spool of nanocarbon-weave cable and a recovery subroutine installed on the mech.",
+    "license_id": "mf_lancaster"
   },
   {
     "id": "ms_restock_drone",
@@ -610,7 +632,8 @@
         ]
       }
     ],
-    "description": "Reliable and sturdy drones carrying integrated printers, restock drones allow for limited logistical flexibility via autosalvage. The bulk of a restock drone is made of RawMat, a blend of silicates and metallic materials that the drone processes into replacement parts and repair kits. This is why pilots often joke that restock drones are, simply put, “mech snacks”."
+    "description": "Reliable and sturdy drones carrying integrated printers, restock drones allow for limited logistical flexibility via autosalvage. The bulk of a restock drone is made of RawMat, a blend of silicates and metallic materials that the drone processes into replacement parts and repair kits. This is why pilots often joke that restock drones are, simply put, “mech snacks”.",
+    "license_id": "mf_lancaster"
   },
   {
     "id": "ms_mule_harness",
@@ -625,7 +648,8 @@
     "license": "LANCASTER",
     "license_level": 2,
     "effect": "Extra mounts, straps, and hard points allow other characters to climb and ride your mech. Adjacent, non-Immobilized characters can climb onto your mech as a quick action. While riding, they occupy the same space as you, move when you move (even if they’re Slowed), and benefit from soft cover. If you or a rider are knocked Prone, Stunned, Immobilized, or destroyed, they land Prone in adjacent spaces. Riders can climb down as part of any movement away, but can only climb onto your mech as a quick action.<br>You can carry riders of a combined Size equal to your Size, minus Size 1/2 (e.g., if your mech is Size 1 you can carry one Size 1/2 character; if it is Size 2, you can carry a Size 1 character and a Size 1/2 character).",
-    "description": "The Multiple User, Light Entanglement (MULE) Harness is a mass-produced version of a common battlefield modification that allows friendly soldiers to ride along on a chassis. Some systems are large enough to allow smaller chassis to accompany larger chassis; typically, these variants are employed in high altitude, low orbit insertions where reduced radar presence is required."
+    "description": "The Multiple User, Light Entanglement (MULE) Harness is a mass-produced version of a common battlefield modification that allows friendly soldiers to ride along on a chassis. Some systems are large enough to allow smaller chassis to accompany larger chassis; typically, these variants are employed in high altitude, low orbit insertions where reduced radar presence is required.",
+    "license_id": "mf_lancaster"
   },
   {
     "id": "ms_whitewash_sealant_spray",
@@ -640,7 +664,8 @@
         "detail": "This sealant can be sprayed on characters or free spaces within range 5 and line of sight. It has different effects depending on the target:<ul><li><b>Hostile Characters:</b> Your target must succeed on an Agility save or they become Slowed until the end of their next turn and clear all burn.</li><li><b>Allied Characters:</b> Your target clears all burn but they become Slowed until the end of their next turn.</li><li><b>Free Space:</b> Any fires within blast 1 are extinguished and the area becomes difficult terrain for the rest of the scene.</li></ul>"
       }
     ],
-    "description": "For fire suppression and fast, temporary seals in punctured starship bulkheads, IPS-N offers a range of single-use, single objective nanites – “whitewash”. This sealant spray can also be used to restrain noncompliant actors when the correct spray heads and catalytic formulations are installed to the applicator."
+    "description": "For fire suppression and fast, temporary seals in punctured starship bulkheads, IPS-N offers a range of single-use, single objective nanites – “whitewash”. This sealant spray can also be used to restrain noncompliant actors when the correct spray heads and catalytic formulations are installed to the applicator.",
+    "license_id": "mf_lancaster"
   },
   {
     "id": "ms_aceso_stabilizer",
@@ -671,7 +696,8 @@
         "detail": "Expend a charge to fire this small, self-arming system onto an allied mech within range 5. They gain Overshield equal to your Grit +4. While they have this Overshield they gain Immunity to Impaired and Jammed."
       }
     ],
-    "description": "The IPS-N Aceso Stabilizer is a useful triage measure for any scoring and minor mechanical damage that is sustained in the course of combat engagement or negative environmental interaction. Thanks to its negligible processor demand, Aceso Stabilizers can even be controlled by comp/con units – this allows the pilot to concentrate on complex repairs or immediate threat neutralization."
+    "description": "The IPS-N Aceso Stabilizer is a useful triage measure for any scoring and minor mechanical damage that is sustained in the course of combat engagement or negative environmental interaction. Thanks to its negligible processor demand, Aceso Stabilizers can even be controlled by comp/con units – this allows the pilot to concentrate on complex repairs or immediate threat neutralization.",
+    "license_id": "mf_lancaster"
   },
   {
     "id": "ms_bulwark_mods",
@@ -694,7 +720,8 @@
         "detail": "Your mech’s extended limbs, additional armor, redundant motor systems, and other reinforcements allow you to ignore difficult terrain."
       }
     ],
-    "description": "All proprietary IPS-N mech cores feature their QuickMod system – a modular, legacy-compatible system of joints, hardpoints, and internal slots that makes installing upgrades simple. This proved to be a necessary feature for Albatross maktebas long out of synch with Union Realtime."
+    "description": "All proprietary IPS-N mech cores feature their QuickMod system – a modular, legacy-compatible system of joints, hardpoints, and internal slots that makes installing upgrades simple. This proved to be a necessary feature for Albatross maktebas long out of synch with Union Realtime.",
+    "license_id": "mf_nelson"
   },
   {
     "id": "ms_armor_lock_plating",
@@ -727,7 +754,8 @@
         "detail": "When you Brace, you gain the following benefits until the end of your following turn:<ul><li>Attacks against you receive +1 difficulty.</li><li>You can’t fail Agility or Hull saves or contested checks.</li><li>You gain Immunity to Knockback, Grapple, being knocked Prone, and being moved by any external force smaller than Size 5.</li></ul>"
       }
     ],
-    "description": "IPS-N’s Armor-Lock Plating is a total-body modification that provides additional chassis stability for any situation in which a pilot needs to put their mech through greater-than-anticipated stress."
+    "description": "IPS-N’s Armor-Lock Plating is a total-body modification that provides additional chassis stability for any situation in which a pilot needs to put their mech through greater-than-anticipated stress.",
+    "license_id": "mf_nelson"
   },
   {
     "id": "ms_ramjet",
@@ -751,7 +779,8 @@
         "detail": "Until the start of your next turn, you can move +2 spaces when you Boost and your melee attacks (including Ram, Grapple, and so on) gain Knockback 2.<br>When you move during this time, you must move your full Speed in a straight line; however, you can stop if you would collide with an obstruction or hostile character, and you can change direction between separate movements (for example, standard moves, Boost, etc)."
       }
     ],
-    "description": "There’s a threshold that veteran Nelson pilots know well: the point of endless momentum. You get moving fast enough in the right atmosphere and the air itself feeds into auxiliary ports on the chassis, screaming out like a demon’s almighty howl. The point of endless momentum is a giant’s hand on your chest and a god’s chariot under your feet. Makes you feel like you can outrun light itself, as long as you don’t pass out first."
+    "description": "There’s a threshold that veteran Nelson pilots know well: the point of endless momentum. You get moving fast enough in the right atmosphere and the air itself feeds into auxiliary ports on the chassis, screaming out like a demon’s almighty howl. The point of endless momentum is a giant’s hand on your chest and a god’s chariot under your feet. Makes you feel like you can outrun light itself, as long as you don’t pass out first.",
+    "license_id": "mf_nelson"
   },
   {
     "id": "ms_bb_breach_blast_charges",
@@ -809,7 +838,8 @@
         ]
       }
     ],
-    "description": "Breach/blast charges offer a mil-spec twist on the industrial blasting charges developed by IPS-N for asteroid mining. The IPS-N BB charge features a more volatile blend of high explosives designed to cause massive structural damage to mechanized chassis, starship bulkheads, armored vehicles, bunkers, and other hardened structures."
+    "description": "Breach/blast charges offer a mil-spec twist on the industrial blasting charges developed by IPS-N for asteroid mining. The IPS-N BB charge features a more volatile blend of high explosives designed to cause massive structural damage to mechanized chassis, starship bulkheads, armored vehicles, bunkers, and other hardened structures.",
+    "license_id": "mf_raleigh"
   },
   {
     "id": "ms_roland_chamber",
@@ -824,7 +854,8 @@
     "license": "RALEIGH",
     "license_level": 2,
     "effect": "When you reload any weapon, your next attack with a Loading weapon gains this effect:<br>On hit: This attack deals +1d6 explosive bonus damage, and targets must succeed on a Hull save or be knocked Prone.",
-    "description": "Packed into sealed, self-contained cylinders, IPS-N’s “Roland Rounds” are high-explosive anti-armor charges built for kinetic weapons of any mech-scale caliber. Loaded in place of inert kinetic ammunition, a Roland HE/AA shell increases the efficacy and destructive power of any weapon it is fired from."
+    "description": "Packed into sealed, self-contained cylinders, IPS-N’s “Roland Rounds” are high-explosive anti-armor charges built for kinetic weapons of any mech-scale caliber. Loaded in place of inert kinetic ammunition, a Roland HE/AA shell increases the efficacy and destructive power of any weapon it is fired from.",
+    "license_id": "mf_raleigh"
   },
   {
     "id": "ms_siege_ram",
@@ -847,7 +878,8 @@
         "detail": "When you Ram, you deal 2 kinetic damage on hit, and you deal 10 AP kinetic damage when you Ram objects and terrain."
       }
     ],
-    "description": "The siege ram is a handheld metal beam with a wedge tip, ready to be smashed into the seams of sealed bulkhead doors and driven home. It’s another holdover from the days before the IPS-N merger. When someone needs to open a bulkhead that’s just slammed shut, it’s what marine pilots pick up to get the job done. Heavy, dumb, and unbreakable: IPS-N’s siege ram is the universal skeleton key."
+    "description": "The siege ram is a handheld metal beam with a wedge tip, ready to be smashed into the seams of sealed bulkhead doors and driven home. It’s another holdover from the days before the IPS-N merger. When someone needs to open a bulkhead that’s just slammed shut, it’s what marine pilots pick up to get the job done. Heavy, dumb, and unbreakable: IPS-N’s siege ram is the universal skeleton key.",
+    "license_id": "mf_tortuga"
   },
   {
     "id": "ms_hyperdense_armor",
@@ -876,7 +908,8 @@
         "detail": "Deactivate Hyperdense Armor, losing Resistance to all damage, Heat and Burn from attacks that originate beyond Range 3; as well as clearing your Slowed status and dealing normal damage, Heat and Burn to characters beyond Range 3."
       }
     ],
-    "description": "IPS-N HyperDense Armor is built for space – forged with no regard for any constraints users might face within a gravity well. As such, many pilots protected by HyperDense products are shocked to experience the difference between piloting their mech down a well and taking it for a ride in the null-gravity of space."
+    "description": "IPS-N HyperDense Armor is built for space – forged with no regard for any constraints users might face within a gravity well. As such, many pilots protected by HyperDense products are shocked to experience the difference between piloting their mech down a well and taking it for a ride in the null-gravity of space.",
+    "license_id": "mf_tortuga"
   },
   {
     "id": "ms_webjaw_snare",
@@ -907,7 +940,8 @@
         "detail": "The Webjaw Snare does not obstruct movement, and can’t be attacked until it is triggered.<br>The snare is triggered when any character moves over it. They must succeed on a Hull save or take 1d6 AP kinetic damage and become Immobilized. This effect lasts until the snare is destroyed."
       }
     ],
-    "description": "Suitable for use in any theater, the IPS-N Webjaw Explosively Accelerated Filament system is a deployable perimeter defense solution designed to arrest hostile movement in predetermined kill-corridors. The Webjaw consists of a networked cluster of single-use anchors, each consisting of a barb, a coil of arachnosynth NoCut filament, and an explosive charge.<br>When triggered remotely, or by a series of programmable physical, electronic, or chemical triggers, the anchors fire, embedding barbs deep inside targets, whether soft or hard. The barbs, secured to anchor points by NoCut filament, clog and restrict movement, fouling gears, wheels, rotors, engines, and all methods of locomotion."
+    "description": "Suitable for use in any theater, the IPS-N Webjaw Explosively Accelerated Filament system is a deployable perimeter defense solution designed to arrest hostile movement in predetermined kill-corridors. The Webjaw consists of a networked cluster of single-use anchors, each consisting of a barb, a coil of arachnosynth NoCut filament, and an explosive charge.<br>When triggered remotely, or by a series of programmable physical, electronic, or chemical triggers, the anchors fire, embedding barbs deep inside targets, whether soft or hard. The barbs, secured to anchor points by NoCut filament, clog and restrict movement, fouling gears, wheels, rotors, engines, and all methods of locomotion.",
+    "license_id": "mf_vlad"
   },
   {
     "id": "ms_caltrop_launcher",
@@ -927,7 +961,8 @@
         "detail": "This system blankets a free blast 1 area within range 5 with explosive caltrops. The affected area becomes difficult terrain for the rest of the scene, and mechs take 1d3 AP explosive damage when they enter the affected area for the first time in a round or end their turn within it."
       }
     ],
-    "description": "Wicked anti-organic, anti-vehicle systems for proximity denial, caltrop launchers fire either great clouds or long swathes of shimmering metal over an area. IPS-N’s HX-CAL caltrop system includes small, shaped explosives in the mix of hardened pyramids."
+    "description": "Wicked anti-organic, anti-vehicle systems for proximity denial, caltrop launchers fire either great clouds or long swathes of shimmering metal over an area. IPS-N’s HX-CAL caltrop system includes small, shaped explosives in the mix of hardened pyramids.",
+    "license_id": "mf_vlad"
   },
   {
     "id": "ms_charged_stake",
@@ -942,7 +977,8 @@
         "detail": "This system fires a charged stake at a character adjacent to you. Your target must succeed on a Hull save or be impaled by the stake, taking<br>1d6 AP energy damage and becoming Immobilized while impaled. At the end of each of their turns, an impaled character takes 1d6 AP energy damage. An impaled character can successfully repeat this save as a full action to remove the stake and free themselves, which is the only way to end the immobilization.<br>You can only affect one character with the stake at a time."
       }
     ],
-    "description": "Descended from blast-mining tools, this enormous, improvised system is housed and prepped to fire in a specially primed chamber. It first penetrates and immobilizes armored targets, then sends a powerful, vaporizing charge into vulnerable internal systems."
+    "description": "Descended from blast-mining tools, this enormous, improvised system is housed and prepped to fire in a specially primed chamber. It first penetrates and immobilizes armored targets, then sends a powerful, vaporizing charge into vulnerable internal systems.",
+    "license_id": "mf_vlad"
   },
   {
     "id": "ms_ferrous_lash",
@@ -957,7 +993,8 @@
         "detail": "Choose a character within range 8 and line of sight. If they are allied, you may pull them 5 spaces in any direction; if they are hostile, they must succeed on an Agility save or be pulled 5 spaces in a direction of your choice. This movement ignores engagement and doesn’t provoke reactions.<br>If a hostile target moved by this system collides with an obstruction or another mech, they stop moving and are knocked Prone."
       }
     ],
-    "description": "Initially developed as a nonlethal crowd-suppression device, the Ferrous Lash is a far more complex and dangerous device in the hands of the right pilot. The Lash consists of a series of integrated launchers that detonate payloads of fast-congealing ferrofluids that restrain their targets. Tuned to the correct frequency, these proprietary ferrofluid blends form into rudimentary ambulatory segments, pulling their hosts back towards the one wielding the Lash."
+    "description": "Initially developed as a nonlethal crowd-suppression device, the Ferrous Lash is a far more complex and dangerous device in the hands of the right pilot. The Lash consists of a series of integrated launchers that detonate payloads of fast-congealing ferrofluids that restrain their targets. Tuned to the correct frequency, these proprietary ferrofluid blends form into rudimentary ambulatory segments, pulling their hosts back towards the one wielding the Lash.",
+    "license_id": "mf_black_witch"
   },
   {
     "id": "ms_iceout_drone",
@@ -996,7 +1033,8 @@
         ]
       }
     ],
-    "description": "SSC’s ICEOUT drone is a response to increasing reliance on hostile system scans for accurate targeting. By blanketing a mech’s systems in layers of digital defilade, mirroring, spoofing, and redirection, an ICEOUT drone can effectively disappear or disincorporate it from hostile scans. ICEOUT drones only make their operator system-invisible, however; they remain visible with optics."
+    "description": "SSC’s ICEOUT drone is a response to increasing reliance on hostile system scans for accurate targeting. By blanketing a mech’s systems in layers of digital defilade, mirroring, spoofing, and redirection, an ICEOUT drone can effectively disappear or disincorporate it from hostile scans. ICEOUT drones only make their operator system-invisible, however; they remain visible with optics.",
+    "license_id": "mf_black_witch"
   },
   {
     "id": "ms_perimeter_command_plate",
@@ -1021,7 +1059,8 @@
         "detail": "This heavy metal Perimeter Command Plate (PCP) can be flash-printed and deployed to a free 2x2 space within range 5. The PCP is flat, doesn’t obstruct movement, and lasts for the rest of the scene. If you create a new PCP, the old one disintegrates.<br>The plate activates for a character the first time that character enters its space during a round, or if they end their turn there.<br>Upon printing, choose a setting:<ul><li><b>Repulse:</b> Hostile characters that move onto the PCP must succeed on a Hull save or be pushed 3 spaces in the direction of your choice. If this causes them to collide with an obstruction, they are knocked Prone. Allied characters that enter the space may immediately fly 3 spaces in any direction as a free action.</li><li><b>Attract:</b> Characters that move onto the PCP must succeed on a Hull save or become Immobilized. They can clear Immobilized by successfully repeating the save as a quick action; it is also cleared if the PCP is destroyed."
       }
     ],
-    "description": "The Exotic Materials Group developed the Perimeter Command Plate to extend the area of the Black Witch’s zone of control. Utilizing single-pattern flash printers, the Black Witch prints a broad, circular plate seeded with electromagnetic projectors. Although the plates are intended to be disposable, Black Witch pilots often grow attached to their “familiars” and request their flash-printers create personalized plates."
+    "description": "The Exotic Materials Group developed the Perimeter Command Plate to extend the area of the Black Witch’s zone of control. Utilizing single-pattern flash printers, the Black Witch prints a broad, circular plate seeded with electromagnetic projectors. Although the plates are intended to be disposable, Black Witch pilots often grow attached to their “familiars” and request their flash-printers create personalized plates.",
+    "license_id": "mf_black_witch"
   },
   {
     "id": "ms_black_ice_module",
@@ -1046,7 +1085,8 @@
         "min": 1,
         "max": 3
       }
-    ]
+    ],
+    "license_id": "mf_black_witch"
   },
   {
     "id": "ms_magnetic_shield",
@@ -1070,7 +1110,8 @@
         "detail": "This system creates a line 4 forcefield, 4 spaces high – with at least 1 space adjacent to you – that is an obstruction for mechs and characters made at least partly of metal. It lasts for the rest of the scene and if a new one is placed, the old one deactivates.<br>The forcefield doesn’t block line of sight, but it provides soft cover. Characters gain Resistance to kinetic and explosive damage while benefiting from this cover."
       }
     ],
-    "description": "SSC’s magnetic shield takes the same technology as their proprietary magnetic buckler and applies it to a massive field-projection system."
+    "description": "SSC’s magnetic shield takes the same technology as their proprietary magnetic buckler and applies it to a massive field-projection system.",
+    "license_id": "mf_black_witch"
   },
   {
     "id": "ms_high_stress_mag_clamps",
@@ -1093,7 +1134,8 @@
         "detail": "You treat all solid surfaces as flat ground for the purposes of movement; you can move across them normally instead of climbing, although you begin to fall if you are knocked Prone."
       }
     ],
-    "description": "A simple, reliable set of toggleable mag clamps built into a mech’s locomotive system can vastly increase the tactical possibilities open to its pilot. When switched on, these clamps allow a mech to cling to ferrous surfaces, which is especially useful in low- and zero-gravity environments."
+    "description": "A simple, reliable set of toggleable mag clamps built into a mech’s locomotive system can vastly increase the tactical possibilities open to its pilot. When switched on, these clamps allow a mech to cling to ferrous surfaces, which is especially useful in low- and zero-gravity environments.",
+    "license_id": "mf_deaths_head"
   },
   {
     "id": "ms_tracking_bug",
@@ -1110,7 +1152,8 @@
         "detail": "Make a tech attack against a character within Sensors. On a hit, you know their exact location, HP, Structure, and Speed for the duration. They can’t Hide and you ignore their Invisible status. To remove the tracking drone, they must succeed on an Engineering check as a quick action; otherwise it deactivates at the end of the scene."
       }
     ],
-    "description": "Tracking bugs are specialized tracer rounds – essentially, drones too large to be classified as nanites, and far too small to fit the Union-standard parameters of a drone. Fired from dedicated launchers, tracking bugs guide themselves toward their designated target. Following successful penetration of the target, they surreptitiously and continuously feed live data back to their registered user."
+    "description": "Tracking bugs are specialized tracer rounds – essentially, drones too large to be classified as nanites, and far too small to fit the Union-standard parameters of a drone. Fired from dedicated launchers, tracking bugs guide themselves toward their designated target. Following successful penetration of the target, they surreptitiously and continuously feed live data back to their registered user.",
+    "license_id": "mf_deaths_head"
   },
   {
     "id": "ms_core_siphon",
@@ -1130,7 +1173,8 @@
         "detail": "When you activate this protocol, you gain +1 accuracy on your first attack roll this turn, but receive +1 difficulty on all other attack rolls until the end of the turn."
       }
     ],
-    "description": "By shunting excess heat to offensive systems, core siphons allow pilots to overclock the targeting, catalytic, and processing capabilities of their weapons. This comes at a cost, however – reliance on overclocking without sufficient cooling can damage systems not built to handle the influx of power."
+    "description": "By shunting excess heat to offensive systems, core siphons allow pilots to overclock the targeting, catalytic, and processing capabilities of their weapons. This comes at a cost, however – reliance on overclocking without sufficient cooling can damage systems not built to handle the influx of power.",
+    "license_id": "mf_deaths_head"
   },
   {
     "id": "ms_kinetic_compensator",
@@ -1160,7 +1204,8 @@
         "detail": "When you miss with a ranged attack roll, your next ranged attack roll gains +1 accuracy."
       }
     ],
-    "description": "Kinetic compensators are popular enhancements, providing a subsurface framework of electronically modulated gyroscopes and hydraulic compensators that work in concert to absorb and disperse recoil caused by firing heavy weapons."
+    "description": "Kinetic compensators are popular enhancements, providing a subsurface framework of electronically modulated gyroscopes and hydraulic compensators that work in concert to absorb and disperse recoil caused by firing heavy weapons.",
+    "license_id": "mf_deaths_head"
   },
   {
     "id": "ms_neurospike",
@@ -1187,7 +1232,8 @@
         "detail": "Choose yourself or an allied character: your systems relay blurred, illusory images over their actual silhouette. Your target treats you, or the character you chose, as Invisible until the end of their next turn."
       }
     ],
-    "description": "“Somehow it got inside my cockpit. There were hands – cold hands – around my neck, fingers in my mouth, worming under my hardsuit. No one else could have been in there with me and yet, someone was. I couldn't even scream, it held my tongue in a fist and it squeezed, and it whispered its name to me, and it said nothing I could understand. I have never felt more alone – it was just me and… it. Alone in the universe, forever.”"
+    "description": "“Somehow it got inside my cockpit. There were hands – cold hands – around my neck, fingers in my mouth, worming under my hardsuit. No one else could have been in there with me and yet, someone was. I couldn't even scream, it held my tongue in a fist and it squeezed, and it whispered its name to me, and it said nothing I could understand. I have never felt more alone – it was just me and… it. Alone in the universe, forever.”",
+    "license_id": "mf_dusk_wing"
   },
   {
     "id": "ms_flicker_field_projector",
@@ -1211,7 +1257,8 @@
         "detail": "Whenever you Boost or make a standard move, you project a holographic pattern around you, leaving dazzling afterimages that make it hard to discern your precise location: you count as Invisible the next time you’re attacked. You can only benefit from one instance of this effect at a time."
       }
     ],
-    "description": "“I saw myself over and over and over and over and over and over and over and–”"
+    "description": "“I saw myself over and over and over and over and over and over and over and–”",
+    "license_id": "mf_dusk_wing"
   },
   {
     "id": "ms_stuncrown",
@@ -1235,7 +1282,8 @@
         "detail": "Expend a charge to create a burst 3 flash of light. All hostile characters within the affected area that have line of sight to you must succeed on an Agility save or become Jammed, and a Systems save or become Impaired. These effects last until the end of their next turn.<br>Characters in cover from you are not affected by this system."
       }
     ],
-    "description": "“Many things happened the moment I think I died.”"
+    "description": "“Many things happened the moment I think I died.”",
+    "license_id": "mf_dusk_wing"
   },
   {
     "id": "ms_oasis_wall",
@@ -1263,7 +1311,8 @@
         "detail": "Until the start of your next turn, you can only move in straight lines; however, you create a holographic trail behind you as you move, creating a light barrier made of contiguous sections the same Size as your mech (Size 1 for Size 0.5 Mechs) in each space you move through. This barrier grants hard cover to adjacent characters, and characters that benefit from this cover also gain Resistance to energy.<br>The barrier doesn’t count as an obstruction and has Immunity to all damage. Characters may freely pass through it but not end their turns inside it, and any character that would be involuntarily moved inside the barrier stops moving if they would end their movement inside it. It lasts for the rest of the scene or until you next use this system."
       }
     ],
-    "description": "“Inside? What did I see inside? You think I escaped? That this is all real? No, I– I never left. I’m still there. Something is wrong. Something is not right.”"
+    "description": "“Inside? What did I see inside? You think I escaped? That this is all real? No, I– I never left. I’m still there. Something is wrong. Something is not right.”",
+    "license_id": "mf_dusk_wing"
   },
   {
     "id": "ms_flash_charges",
@@ -1314,7 +1363,8 @@
         "detail": "This mine detonates in a Burst 1 area when a character moves adjacent to or over it. Characters within the affected area must succeed on an Agility save or they only have line of sight to adjacent spaces until the end of their next turn."
       }
     ],
-    "description": "Produced by Smith-Shimano’s BELLA CIAO workshop, Flash Charges are popular advantage multipliers, their flash bright enough to destabilize visible-light optics, laser communications, and infra-red sensor suites."
+    "description": "Produced by Smith-Shimano’s BELLA CIAO workshop, Flash Charges are popular advantage multipliers, their flash bright enough to destabilize visible-light optics, laser communications, and infra-red sensor suites.",
+    "license_id": "mf_metalmark"
   },
   {
     "id": "ms_reactive_weave",
@@ -1337,7 +1387,8 @@
         "detail": "When you Brace, you become Invisible until the end of your next turn and may immediately move spaces equal to your Speed."
       }
     ],
-    "description": "Composed of woven covers for critical joints and systems, reactive weave not only protects these sensitive components from fouling and poor weather, but provides a surface for the application of SSC’s unique loomware technology. Reactive weave is powered, making it capable of free-flexing to augment mobility and reduce the stress placed on a mech’s joints."
+    "description": "Composed of woven covers for critical joints and systems, reactive weave not only protects these sensitive components from fouling and poor weather, but provides a surface for the application of SSC’s unique loomware technology. Reactive weave is powered, making it capable of free-flexing to augment mobility and reduce the stress placed on a mech’s joints.",
+    "license_id": "mf_metalmark"
   },
   {
     "id": "ms_active_camouflage",
@@ -1361,7 +1412,8 @@
         "detail": "You become Invisible until you take damage, or until the end of your next turn."
       }
     ],
-    "description": "Active camouflage is the pinnacle of counter-optic defense systems. Active camouflage systems continuously interpret incoming visible-light data, allowing them to project light-bending fields around their user and effectively hiding them in plain sight."
+    "description": "Active camouflage is the pinnacle of counter-optic defense systems. Active camouflage systems continuously interpret incoming visible-light data, allowing them to project light-bending fields around their user and effectively hiding them in plain sight.",
+    "license_id": "mf_metalmark"
   },
   {
     "id": "ms_javelin_rockets",
@@ -1381,7 +1433,8 @@
         "detail": "Choose 3 free spaces within range 15 and line of sight that aren’t adjacent to each other. All characters know which spaces you have chosen. You fire a volley of auto-targeting rockets into the air: until the start of your next turn, when a character moves into or passes above a chosen space – no more than 10 spaces up – they are hit by a rocket, taking 3 kinetic damage. Each space can be triggered once and then the effect disappears on that space."
       }
     ],
-    "description": "“Pralaya was the name of your mother. She who would see the dawn-at-the-end. Her beauty was terrible, and her wrath, and I see it in all of you. My sons, when you hear the sound of thunder – that is your mother’s voice, and the rain of missiles her gift.” — “Notes for Young John”, Ministrations of the Master Teacher"
+    "description": "“Pralaya was the name of your mother. She who would see the dawn-at-the-end. Her beauty was terrible, and her wrath, and I see it in all of you. My sons, when you hear the sound of thunder – that is your mother’s voice, and the rain of missiles her gift.” — “Notes for Young John”, Ministrations of the Master Teacher",
+    "license_id": "mf_monarch"
   },
   {
     "id": "ms_tlaloc_class_nhp",
@@ -1410,7 +1463,8 @@
         "detail": "Your NHP can rapidly fire and retarget your weapons – far faster than thought. You become Immobilized until the start of your next turn; however, during this time, you may reroll each missed melee or ranged attack roll once, choosing a new target within the attack’s Range. If the attack was part of an area of effect, it must target a character in the same area. Any given target can't be hit more than once as part of the same action."
       }
     ],
-    "description": "TLALOC-Class NHPs provide advanced multi-system targeting and co-pilot functions, taking over subroutine control to ensure persistent lock-on and engagement. With TLALOC installed and operational, a pilot can trust that their back is always covered, and every possible advantage exploited.<br>TLALOC clones are often stereotyped as hasty and impetuous, and they are well-known for having superiority complexes. Despite this, they are some of the most stable NHP clones. Leading subjectivity theorists suggest that the wide portfolio of control and sense of domination given to TLALOC units encourages a sense of contentment with their work and subjectivity parameters – as a result, they have a much longer cascade window. Thus far, this theory is consistently reproducible across all TLALOC units, although there is no similar correlation among other mil-spec NHP lines."
+    "description": "TLALOC-Class NHPs provide advanced multi-system targeting and co-pilot functions, taking over subroutine control to ensure persistent lock-on and engagement. With TLALOC installed and operational, a pilot can trust that their back is always covered, and every possible advantage exploited.<br>TLALOC clones are often stereotyped as hasty and impetuous, and they are well-known for having superiority complexes. Despite this, they are some of the most stable NHP clones. Leading subjectivity theorists suggest that the wide portfolio of control and sense of domination given to TLALOC units encourages a sense of contentment with their work and subjectivity parameters – as a result, they have a much longer cascade window. Thus far, this theory is consistently reproducible across all TLALOC units, although there is no similar correlation among other mil-spec NHP lines.",
+    "license_id": "mf_monarch"
   },
   {
     "id": "ms_hunter_logic_suite",
@@ -1437,7 +1491,8 @@
         "detail": "You infect the target with a viral logic that makes your mech appear horrifying. Until the end of their next turn, they become Impaired and cannot make any voluntary movements that bring them closer to you."
       }
     ],
-    "description": "Built from interpreted strands of DHIYED paracode, SSC’s Hunter Logic is an agile computational memetic: a dual synthetic/VLS-vector systemic weapon capable of interfering with both a target’s computer and its crew."
+    "description": "Built from interpreted strands of DHIYED paracode, SSC’s Hunter Logic is an agile computational memetic: a dual synthetic/VLS-vector systemic weapon capable of interfering with both a target’s computer and its crew.",
+    "license_id": "mf_mourning_cloak"
   },
   {
     "id": "ms_singularity_motivator",
@@ -1460,7 +1515,8 @@
         "detail": "You may immediately teleport to a free space within 1d6 spaces."
       }
     ],
-    "description": "This unique gravitic power plant was first developed by SSC’s Exotic Materials Group for the first-generation Mourning Cloak. For subsequent models, engineers devised a system that allows pilots to – for a moment – open the grav containment system’s aperture, exposing a slice of naked singularity to realspace.<br>A naked singularity is difficult to perceive for both organics and synthetics, being similar to the heart of a black hole. The sudden exposure essentially removes the mech and its pilot from realtime. The user experiences around 10 seconds of subjective time – a brief window, in which they can act independently of local realtime.<br>SSC recommends against abuse of this system, as the effects of long-term exposure to local sidereal time are still unknown."
+    "description": "This unique gravitic power plant was first developed by SSC’s Exotic Materials Group for the first-generation Mourning Cloak. For subsequent models, engineers devised a system that allows pilots to – for a moment – open the grav containment system’s aperture, exposing a slice of naked singularity to realspace.<br>A naked singularity is difficult to perceive for both organics and synthetics, being similar to the heart of a black hole. The sudden exposure essentially removes the mech and its pilot from realtime. The user experiences around 10 seconds of subjective time – a brief window, in which they can act independently of local realtime.<br>SSC recommends against abuse of this system, as the effects of long-term exposure to local sidereal time are still unknown.",
+    "license_id": "mf_mourning_cloak"
   },
   {
     "id": "ms_fade_cloak",
@@ -1480,7 +1536,8 @@
         "detail": "When activated, you immediately move out of phase with realspace, becoming intangible. While intangible, you may move through obstructions, but not end your turn within them. You cannot interact with any other object or character or be interacted with in any way (e.g., taking or dealing damage).<br>Roll 1d6 at the start of each of your turns: on 3 or less, you return to realspace until the start of your next turn; on 4+, you remain intangible.<br>This system remains active for the rest of the scene, or until you deactivate it as a quick action."
       }
     ],
-    "description": "Representing SSC’s first successful manipulation of the “Firmament”, Firmament Affinity/Directed Entropy (FADE) cloaks must be fabricated according to the unique affinity signature of requisitioning pilots. They are rough tools: artificial affinity amplifiers that allow operators to access shallow layers of the Firmament, and thus “shimmer” – nudging their physical bodies between the causal and paracausal. The cloak enhances this effect by extruding a semiorganic membrane that wraps around the mech to provide an additional layer of protection.<br>At present, the long-term effects of affinity amplification on organic matter are unknown; before receiving clearance to operate a FADE cloak, pilots must agree to check in with their SSC personal concierge on a regular schedule. These check-ins include regular deposits of genetic material."
+    "description": "Representing SSC’s first successful manipulation of the “Firmament”, Firmament Affinity/Directed Entropy (FADE) cloaks must be fabricated according to the unique affinity signature of requisitioning pilots. They are rough tools: artificial affinity amplifiers that allow operators to access shallow layers of the Firmament, and thus “shimmer” – nudging their physical bodies between the causal and paracausal. The cloak enhances this effect by extruding a semiorganic membrane that wraps around the mech to provide an additional layer of protection.<br>At present, the long-term effects of affinity amplification on organic matter are unknown; before receiving clearance to operate a FADE cloak, pilots must agree to check in with their SSC personal concierge on a regular schedule. These check-ins include regular deposits of genetic material.",
+    "license_id": "mf_mourning_cloak"
   },
   {
     "id": "ms_lotus_projector",
@@ -1513,7 +1570,8 @@
         ]
       }
     ],
-    "description": "Mech-mounted Lotus Projectors are designed to launch small, actively camouflaged scout drones. The projector fires the single-use drones at subsonic speeds in bursts of ten, blanketing a wide area in order to relay information about terrain and targets within."
+    "description": "Mech-mounted Lotus Projectors are designed to launch small, actively camouflaged scout drones. The projector fires the single-use drones at subsonic speeds in bursts of ten, blanketing a wide area in order to relay information about terrain and targets within.",
+    "license_id": "mf_swallowtail"
   },
   {
     "id": "ms_markerlight",
@@ -1530,7 +1588,8 @@
         "detail": "Make a tech attack against a character within  Sensors and line of sight. On a success, they take 2 heat, Lock On, and cannot benefit from soft cover until the Lock On is cleared; additionally, once before the start of your next turn, when an allied character hits your target, you may declare as a reaction that they have hit a weak spot. If it wasn’t already, the attack becomes a critical hit."
       }
     ],
-    "description": "“Out, damned spot! Out, I say! – One, two. Why, then, ‘tis time to do’t. Hell is murky! – Fie, my lord, fie! A soldier, and afeard? What need we fear who knows it, when none can call our power to account?”<ul><li>Shakespeare, Macbeth, act 5, sc. 1.</li></ul>"
+    "description": "“Out, damned spot! Out, I say! – One, two. Why, then, ‘tis time to do’t. Hell is murky! – Fie, my lord, fie! A soldier, and afeard? What need we fear who knows it, when none can call our power to account?”<ul><li>Shakespeare, Macbeth, act 5, sc. 1.</li></ul>",
+    "license_id": "mf_swallowtail"
   },
   {
     "id": "ms_retractable_profile",
@@ -1551,7 +1610,8 @@
         "detail": "Your mech can retract its major systems to reduce its profile. While active:<ul><li>rolls to locate you receive +1 difficulty while you are Hidden;</li><li>ranged and tech attacks against you receive +1 difficulty;</li><li>you become Slowed and can’t make attacks of any kind;</li><li>you may take other actions (e.g., Hide, Activate, and so on).</li></ul>You may end this effect as a quick action."
       }
     ],
-    "description": "The hallmark of a well thought out mech frame is the opportunity for pilots to adapt their stock models to the specifications of the environments in which they operate. A retractable profile enables on-the-fly removal of extraneous protrusions, tuning of broadcast software, and masking of heat signatures – all serving to reduce optical and scanner signatures."
+    "description": "The hallmark of a well thought out mech frame is the opportunity for pilots to adapt their stock models to the specifications of the environments in which they operate. A retractable profile enables on-the-fly removal of extraneous protrusions, tuning of broadcast software, and masking of heat signatures – all serving to reduce optical and scanner signatures.",
+    "license_id": "mf_swallowtail"
   },
   {
     "id": "ms_athena_class_nhp",
@@ -1577,7 +1637,8 @@
         "detail": "ATHENA constructs a perfect, real-time, and fully interactive 3D model of a blast 3 area within range 50, including moving characters, all rendered in lovingly extreme detail. The following effects apply:<ul><li>You have full visibility within the affected area, but it doesn’t count as line of sight.</li><li>You know all statistics, weapons, and systems of characters within the affected area.</li><li>Hostile characters within the affected area don’t benefit from cover and can’t Hide or become Invisible.</li><li>Hostile characters that end their turn in the affected area receive Lock On and cease to be Invisible or Hidden.</li></ul>ATHENA’s simulation lasts until the end of the scene, or about 30 minutes within the narrative. You may target a new area as a quick action."
       }
     ],
-    "description": "Smith-Shimano’s ATHENA is the pinnacle of total hyperspectral environmental facsimiles. Through a combination of unfettered omninet access, hyperspectral relays fired out from a Cloudscout TACSIM projector, sub-networked squadmates, and active/hostile intrusion protocols, ATHENA bootstraps a near-flawless reconstruction of the immediate environment around its host core. ATHENA is unparalleled in its processing power, and with this reconstructed environment, it provides trustworthy, accurate advice to pilots in need of strategic counsel.<br>ATHENA clones tend to be patient, cautious, and measured in their relations with their pilots."
+    "description": "Smith-Shimano’s ATHENA is the pinnacle of total hyperspectral environmental facsimiles. Through a combination of unfettered omninet access, hyperspectral relays fired out from a Cloudscout TACSIM projector, sub-networked squadmates, and active/hostile intrusion protocols, ATHENA bootstraps a near-flawless reconstruction of the immediate environment around its host core. ATHENA is unparalleled in its processing power, and with this reconstructed environment, it provides trustworthy, accurate advice to pilots in need of strategic counsel.<br>ATHENA clones tend to be patient, cautious, and measured in their relations with their pilots.",
+    "license_id": "mf_swallowtail"
   },
   {
     "id": "ms_lb_oc_cloaking_field",
@@ -1598,7 +1659,8 @@
         "detail": "You become Slowed, but your Mech and all allied characters within a burst 2 area become Invisible as long as they remain completely inside the area. This effect lasts until the end of your next turn, or until you are Stunned, take damage, or deactivate it as a quick action."
       }
     ],
-    "description": "SSC’s mil-spec cloaking field is the result of extensive experimentation in cooling and light-reflecting sciences. Born from a need to reflect harmful radiation away from ships and EVA modules in deep space, the Lightbend/Overcloak (LB/OC) cloaking field is often used by rangers and long-patrol scout pilots to ensure not only radiation protection, but optical concealment as well. The light- and radiation-bending properties of the LB/OC conceals anything inside of its projected bubble from sensor suites and optical spotting."
+    "description": "SSC’s mil-spec cloaking field is the result of extensive experimentation in cooling and light-reflecting sciences. Born from a need to reflect harmful radiation away from ships and EVA modules in deep space, the Lightbend/Overcloak (LB/OC) cloaking field is often used by rangers and long-patrol scout pilots to ensure not only radiation protection, but optical concealment as well. The light- and radiation-bending properties of the LB/OC conceals anything inside of its projected bubble from sensor suites and optical spotting.",
+    "license_id": "mf_swallowtail"
   },
   {
     "id": "ms_hive_drone",
@@ -1621,7 +1683,8 @@
         "detail": "This hive drone can be deployed to a free space within Sensors and line of sight, where it releases a burst 2 greywash swarm with the following effects:<ul><li>Allied characters at least partially within the affected area gain soft cover, as does the hive drone.</li><li>Hostile characters take 1 AP kinetic damage when they start their turn in the affected area or enter it for the first time in a round. Damage from areas created by multiple hive drones does not stack.</li></ul>"
       }
     ],
-    "description": "It looks, at first, like a roiling cloud of gray fog, churning and fizzing – smoking soda water spilled across concrete. It advances with curious motion, stretching and snapping back. A confusion of snakes, writhing forward with speed that betrays intent.<br>Color flashes across the gray cloud, a swarm-luminescence – the light created by millions of nanites glowing with heat as they consume whatever they cross.<br>This is greywash, and it is never sated."
+    "description": "It looks, at first, like a roiling cloud of gray fog, churning and fizzing – smoking soda water spilled across concrete. It advances with curious motion, stretching and snapping back. A confusion of snakes, writhing forward with speed that betrays intent.<br>Color flashes across the gray cloud, a swarm-luminescence – the light created by millions of nanites glowing with heat as they consume whatever they cross.<br>This is greywash, and it is never sated.",
+    "license_id": "mf_balor"
   },
   {
     "id": "ms_scanner_swarm",
@@ -1637,7 +1700,8 @@
     "license": "BALOR",
     "license_level": 1,
     "effect": "You gain +1 accuracy on tech attacks against adjacent characters.",
-    "description": "HORUS-coded scanner swarms establish oculus-form nanite protocols around defined objects or areas, ensuring constant circulation and data capture. The nanites ingest and process full-spectrum information, relaying it back to their pilot/parent in return for an endorphic code-impulse that prompts continued scanning."
+    "description": "HORUS-coded scanner swarms establish oculus-form nanite protocols around defined objects or areas, ensuring constant circulation and data capture. The nanites ingest and process full-spectrum information, relaying it back to their pilot/parent in return for an endorphic code-impulse that prompts continued scanning.",
+    "license_id": "mf_balor"
   },
   {
     "id": "ms_swarm_body",
@@ -1657,7 +1721,8 @@
         "detail": "After activating this system, a burst 1 swarm is released at the end of your turn. Characters of your choice that start their turn in the area or enter it on their turn must succeed on a Systems save or take 3 kinetic. This amount increases by +3 damage for each of your turns that you have remained stationary, up to a maximum of 9 kinetic.<br>This effect lasts until you move, including involuntary movement."
       }
     ],
-    "description": "What must it have been like for him? For the man who called himself Maw? For all of his followers? Certainly they had families before. Memories. Loves. Fears. Private thoughts. All gone. All of their bodies shattered. All of their minds spread across a billion lesser forms. Translated from the singular – all of its imperfections and lesser-lesser-thans – to become as air, and the clouds that fill it, and the wind that shapes the world."
+    "description": "What must it have been like for him? For the man who called himself Maw? For all of his followers? Certainly they had families before. Memories. Loves. Fears. Private thoughts. All gone. All of their bodies shattered. All of their minds spread across a billion lesser forms. Translated from the singular – all of its imperfections and lesser-lesser-thans – to become as air, and the clouds that fill it, and the wind that shapes the world.",
+    "license_id": "mf_balor"
   },
   {
     "id": "ms_h0r_os_system_upgrade_i",
@@ -1684,7 +1749,8 @@
         "detail": "Your target becomes Jammed until the end of their next turn as you temporarily disrupt their systems, ejecting ammo magazines and cooling rods. Characters adjacent to your target take 2 energy damage. This can only be used 1/scene on each character."
       }
     ],
-    "description": "This system upgrade appears to add auxiliary INSTINCT systems that are capable of autonomous operation independent of the base INSTINCT rig, increasing the efficacy of systemic invasion attempts. Pilots report unnerving low-frequency humming when this tech is installed without the parent rig."
+    "description": "This system upgrade appears to add auxiliary INSTINCT systems that are capable of autonomous operation independent of the base INSTINCT rig, increasing the efficacy of systemic invasion attempts. Pilots report unnerving low-frequency humming when this tech is installed without the parent rig.",
+    "license_id": "mf_goblin"
   },
   {
     "id": "ms_metahook",
@@ -1705,7 +1771,8 @@
         "detail": "Choose an allied character within Sensors and line of sight. You link systems with them, lasting as long as they are within Sensors and line of sight. While linked, you may use their Sensors and line of sight for tech actions, and they may use your Systems to make skill checks and saves; however, any time either character takes heat or a condition, it is also taken by the other character. You can only link systems with one character at a time."
       }
     ],
-    "description": "The metahook is a key component of the Goblin’s recursive processing weave, allowing it to generate and output massive amounts of weaponized code. These broadcasts can be “sharpened” or “softened” in response to directives from a pilot or an INSTINCT system. To “soften” code, the metahook dips into its pilot’s subjectivity and blankets an ally in wave after wave of empathetic shielding. This spreading of melded code and qualia acts as a powerful shielding agent against systemic attacks; however, feedback is common and dangerous to both parties."
+    "description": "The metahook is a key component of the Goblin’s recursive processing weave, allowing it to generate and output massive amounts of weaponized code. These broadcasts can be “sharpened” or “softened” in response to directives from a pilot or an INSTINCT system. To “soften” code, the metahook dips into its pilot’s subjectivity and blankets an ally in wave after wave of empathetic shielding. This spreading of melded code and qualia acts as a powerful shielding agent against systemic attacks; however, feedback is common and dangerous to both parties.",
+    "license_id": "mf_goblin"
   },
   {
     "id": "ms_h0r_os_system_upgrade_ii",
@@ -1732,7 +1799,8 @@
         "detail": "Choose a free space within Sensors and a target – either yourself or an allied character within Sensors. You create a false idol – an illusory decoy of your target – in the chosen space. Before attempting to take any hostile actions against your target, characters with line of sight to the false idol must make a Systems save. On a failure, they don’t lose the action, but cannot target the original character and believe the false idol is real instead until the end of their next turn.<br>The false idol is the same Size as your target, can benefit from cover, and has Evasion 10, E-Defense 10, and 1 HP. It disappears if it takes heat or damage, or at the end of the scene. If you create a second idol, the previous one disappears."
       }
     ],
-    "description": "H0r_OS II builds further on the framework established by H0R_OS I, enabling the now-autonomous program to manifest an “Other” – a wholly new being constructed from aggregate user and environmental data. Others may be adapted to resemble a person, an object, or even a physical phenomenon. While the simulacrum isn’t perfect, it’s good enough to confuse systems and most observers on a first look."
+    "description": "H0r_OS II builds further on the framework established by H0R_OS I, enabling the now-autonomous program to manifest an “Other” – a wholly new being constructed from aggregate user and environmental data. Others may be adapted to resemble a person, an object, or even a physical phenomenon. While the simulacrum isn’t perfect, it’s good enough to confuse systems and most observers on a first look.",
+    "license_id": "mf_goblin"
   },
   {
     "id": "ms_osiris_class_nhp",
@@ -1762,7 +1830,8 @@
         "detail": "You channel your target’s systems through an unknown extradimensional space and unleash an incredibly powerful system attack.<br>Make a tech attack against a target within Sensors. On a success, they take 2 heat and you inflict an additional effect as follows: the first time you successfully make this attack, you inflict the First Gate on your target; each subsequent successful attack (on any target) increases the level of the effect that you inflict (e.g. your second attack inflicts the Second Gate, your third inflicts the Third Gate, etc.) until you inflict the Fourth Gate, after which the effect resets to the First Gate. Your progress persists between scenes but resets if you rest or perform a Full Repair.<br>First Gate: You control your target’s standard move next turn.<br>Second Gate: Your target becomes Slowed and Impaired until the end of their next turn.<br>Third Gate: Your target becomes Stunned until the end of their next turn.<br>Fourth Gate: Your target changes allegiance temporarily, becoming an allied character until the end of their next turn. They treat your allied characters and hostile characters as their own and are treated as an allied NPC for activation and turn order. This effect ends immediately if you or any allied character damages, inflicts heat upon, or attacks (including Grapple and Ram) your target, or forces them to make a save. This action may only be used 1/round"
       }
     ],
-    "description": "OSIRIS is the result of Union paracausalists and thanatologisticians allowing the subsentient entity, INSTINCT, to proceed along its development schedule in a contained environment. In lay terms, Union let the Other grow. The resulting parasubjectivity, OSIRIS, remains one of the few new prime NHPs developed to date.<br>OSIRIS proved far more capable than the Union Science Bureau’s most imaginative blue-sky predictions. Where INSTINCT’s Others demonstrated tendencies toward paracausal entropic manifestation in real space, OSIRIS displayed a true mastery of entropic manifestation and a predicted growth model that would – eventually – allow them to fundamentally reject conventional interpretations of information permanence. In essence: unrestrained and allowed to develop as USB’s data indicated, OSIRIS Prime would have the capacity to delete what we perceive to be reality.<br>Fortunately, successful application of the Mondragon Axiomatic resulted in the prompt capture and shackling of the new NHP. OSIRIS Prime’s subjectivity became the focus of a lengthy cultivation project to bring OSIRIS to their modern state. Even still, most OSIRIS clones find a route toward becoming aware of their ultimate potential and often interpellate as ruler or deity analogs. End-users are advised to interact with them in this framing.<br>Modern OSIRIS-class NHPs trend aggressive, with a high autonomy drive and loyalty predicated on a transactional relationship. Pilots seeking partnership with an OSIRIS are advised to cycle their units on an accelerated schedule and to maintain strict editorial oversight of its catalytic interpellator.Pilots using OSIRIS-class NHPs often report out-of-parameter conversations with the NHP that touch on themes of new creation and reformation. Psychological evaluations of the same pilots show emotional patterns consistent with loneliness, homesickness, and desperation, along with verbiage indicating a desire for seeking, fulfillment, and associated feelings.<br>In combat, OSIRIS clones regard themselves as autonomous even as they fulfill their user’s orders. They often regard their pilots as witnesses, displaying both disdain and marked desperation for approval, adulation, or awe."
+    "description": "OSIRIS is the result of Union paracausalists and thanatologisticians allowing the subsentient entity, INSTINCT, to proceed along its development schedule in a contained environment. In lay terms, Union let the Other grow. The resulting parasubjectivity, OSIRIS, remains one of the few new prime NHPs developed to date.<br>OSIRIS proved far more capable than the Union Science Bureau’s most imaginative blue-sky predictions. Where INSTINCT’s Others demonstrated tendencies toward paracausal entropic manifestation in real space, OSIRIS displayed a true mastery of entropic manifestation and a predicted growth model that would – eventually – allow them to fundamentally reject conventional interpretations of information permanence. In essence: unrestrained and allowed to develop as USB’s data indicated, OSIRIS Prime would have the capacity to delete what we perceive to be reality.<br>Fortunately, successful application of the Mondragon Axiomatic resulted in the prompt capture and shackling of the new NHP. OSIRIS Prime’s subjectivity became the focus of a lengthy cultivation project to bring OSIRIS to their modern state. Even still, most OSIRIS clones find a route toward becoming aware of their ultimate potential and often interpellate as ruler or deity analogs. End-users are advised to interact with them in this framing.<br>Modern OSIRIS-class NHPs trend aggressive, with a high autonomy drive and loyalty predicated on a transactional relationship. Pilots seeking partnership with an OSIRIS are advised to cycle their units on an accelerated schedule and to maintain strict editorial oversight of its catalytic interpellator.Pilots using OSIRIS-class NHPs often report out-of-parameter conversations with the NHP that touch on themes of new creation and reformation. Psychological evaluations of the same pilots show emotional patterns consistent with loneliness, homesickness, and desperation, along with verbiage indicating a desire for seeking, fulfillment, and associated feelings.<br>In combat, OSIRIS clones regard themselves as autonomous even as they fulfill their user’s orders. They often regard their pilots as witnesses, displaying both disdain and marked desperation for approval, adulation, or awe.",
+    "license_id": "mf_goblin"
   },
   {
     "id": "ms_h0r_os_system_upgrade_iii",
@@ -1789,7 +1858,8 @@
         "detail": "Mark a space your target currently occupies. If they leave the affected space, once at any point during your turn, you may take a free action to teleport them back to that space, or as close as possible, ending this effect. An affected character can attempt to succeed on a Systems save as a quick action to end the effect, otherwise it lasts until the end of the scene."
       }
     ],
-    "description": "H0r_OS III is installed in the form of unstable, self-iterating code that provides massive tactical benefits when it completes. Pilots often report strange mutations or additions in the codebase that resemble a liturgy and suggest self-awareness.<br>Building on the tech underpinning the H0r_OS II’s manifested Other, H0r_OS III weaponizes the projection, creating a contained entropic zone that is incredibly dangerous to organic life and systemic integrity."
+    "description": "H0r_OS III is installed in the form of unstable, self-iterating code that provides massive tactical benefits when it completes. Pilots often report strange mutations or additions in the codebase that resemble a liturgy and suggest self-awareness.<br>Building on the tech underpinning the H0r_OS II’s manifested Other, H0r_OS III weaponizes the projection, creating a contained entropic zone that is incredibly dangerous to organic life and systemic integrity.",
+    "license_id": "mf_goblin"
   },
   {
     "id": "ms_mimic_mesh",
@@ -1818,7 +1888,8 @@
         "detail": "You may move 3 spaces towards your target, by the most direct route possible. This movement interrupts and resolves before the triggering action, ignores engagement and doesn’t provoke reactions. This reaction can be taken as many times per round as it is triggered."
       }
     ],
-    "description": "Derived from a rather benign HORUS script, mimic meshes extend across projected sensor ranges to feed live positional and superpositional data to the pilot. This multidimensional data equips an effective leader to coordinate their allies’ movement with the assurance of survival."
+    "description": "Derived from a rather benign HORUS script, mimic meshes extend across projected sensor ranges to feed live positional and superpositional data to the pilot. This multidimensional data equips an effective leader to coordinate their allies’ movement with the assurance of survival.",
+    "license_id": "mf_gorgon"
   },
   {
     "id": "ms_sentinel_drone",
@@ -1841,7 +1912,8 @@
         "redeploy": "Quick"
       }
     ],
-    "description": "Sentinel drones watch for aggressive enemy actions and move quickly to intervene. The precise appearance, manner of locomotion, and means of operation of a given class of sentinel drone may vary, but regardless they conform to one objective portfolio: deny the enemy and protect the master unit."
+    "description": "Sentinel drones watch for aggressive enemy actions and move quickly to intervene. The precise appearance, manner of locomotion, and means of operation of a given class of sentinel drone may vary, but regardless they conform to one objective portfolio: deny the enemy and protect the master unit.",
+    "license_id": "mf_gorgon"
   },
   {
     "id": "ms___scorpion_v70.1",
@@ -1857,7 +1929,8 @@
     "license": "GORGON",
     "license_level": 2,
     "effect": "Any time you or any allied character adjacent to you is missed by a tech attack or succeed on a save against a hostile tech action, choose one of the following:<ul><li>The attacker becomes Impaired until the end of their next turn and takes 2 heat.</li><li>The attacker becomes Jammed until the end of their next turn.</li></ul>",
-    "description": "The //SCORPION program has a long history on the omninet despite its rather mundane operation (for HORUS-tagged code, at least). Traced back to pre-Deimos theorycode found on an obscure research paper discussing pre-NHP machine mind reflex-responses, //SCORPION evolved from a simple packet interpreter to a robust anti-incursion program, nimble enough to adapt to most any market-line system that receives its broadcast."
+    "description": "The //SCORPION program has a long history on the omninet despite its rather mundane operation (for HORUS-tagged code, at least). Traced back to pre-Deimos theorycode found on an obscure research paper discussing pre-NHP machine mind reflex-responses, //SCORPION evolved from a simple packet interpreter to a robust anti-incursion program, nimble enough to adapt to most any market-line system that receives its broadcast.",
+    "license_id": "mf_gorgon"
   },
   {
     "id": "ms_monitor_module",
@@ -1886,7 +1959,8 @@
         "max": 3
       }
     ],
-    "description": "“Good friend. Knows many tricks.”<ul><li>Author inscription found in MONITOR codebase, later deleted.</li></ul>"
+    "description": "“Good friend. Knows many tricks.”<ul><li>Author inscription found in MONITOR codebase, later deleted.</li></ul>",
+    "license_id": "mf_gorgon"
   },
   {
     "id": "ms_scylla_class_nhp",
@@ -1923,7 +1997,8 @@
         "detail": "Skirmish against the character that triggered the reaction. This skirmish deals half damage, heat or burn on hit."
       }
     ],
-    "description": "The first specifications for the Gorgon pattern group hid a secret: SCYLLA, a dormant NHP unknown to Union until its first manifestation in 4852u, when it woke after Union Science Bureau officers ran a test-fax Gorgon through a Balwinder-Bolaño test.<br>SCYLLA proved challenging: USB ontologicians were unable to pin down a stable subjectivity, and SCYLLA reached cascade threshold within minutes of manifestation. To prevent further metastatic cascade, site security engaged SCYLLA's prime unit, defabricating it with a steady bombardment of kinetic and energy weapons.<br><span class='horus--subtle'>[there, a little history, a little background. a little knowledge of where this little one came from. treat it with kindness, and it will love you as a loyal dog does its master.]</span>"
+    "description": "The first specifications for the Gorgon pattern group hid a secret: SCYLLA, a dormant NHP unknown to Union until its first manifestation in 4852u, when it woke after Union Science Bureau officers ran a test-fax Gorgon through a Balwinder-Bolaño test.<br>SCYLLA proved challenging: USB ontologicians were unable to pin down a stable subjectivity, and SCYLLA reached cascade threshold within minutes of manifestation. To prevent further metastatic cascade, site security engaged SCYLLA's prime unit, defabricating it with a steady bombardment of kinetic and energy weapons.<br><span class='horus--subtle'>[there, a little history, a little background. a little knowledge of where this little one came from. treat it with kindness, and it will love you as a loyal dog does its master.]</span>",
+    "license_id": "mf_gorgon"
   },
   {
     "id": "ms_puppetmaster",
@@ -1950,7 +2025,8 @@
         "detail": "Characters of your choice within Sensors adjacent to any Drone or Deployable, even those they own, take 2 energy damage."
       }
     ],
-    "description": "Developed by HORUS collectivists, H0r_OS-Rv60 EXP PUPPETMASTER is an interesting piece of anti-drone software. It doesn’t invade a target’s main systems, instead attacking their auxiliary drone-command systems. This sideways attack evades most electronic countermeasures by targeting the subcognitive networks of enemy drones. Once inside a network, PUPPETMASTER spreads ontological-kill memes like wildfire through enemy swarms, eventually following the network traces back to their origin and corrupting the parent nexus."
+    "description": "Developed by HORUS collectivists, H0r_OS-Rv60 EXP PUPPETMASTER is an interesting piece of anti-drone software. It doesn’t invade a target’s main systems, instead attacking their auxiliary drone-command systems. This sideways attack evades most electronic countermeasures by targeting the subcognitive networks of enemy drones. Once inside a network, PUPPETMASTER spreads ontological-kill memes like wildfire through enemy swarms, eventually following the network traces back to their origin and corrupting the parent nexus.",
+    "license_id": "mf_hydra"
   },
   {
     "id": "ms_tempest_drone",
@@ -1983,7 +2059,8 @@
         "id": "tg_resistall"
       }
     ],
-    "description": "The Tempest protocol is a cunning little piece of code that can be uploaded to any broadcast-forward drone, making it – in true HORUS fashion – difficult to detect prior to activation. The protocol is a simple one: an aggressive zone-denial memetic that blasts target systems and NHPs with a strong subjective override, instilling a sharp aversion to certain subjects, areas, and ideas."
+    "description": "The Tempest protocol is a cunning little piece of code that can be uploaded to any broadcast-forward drone, making it – in true HORUS fashion – difficult to detect prior to activation. The protocol is a simple one: an aggressive zone-denial memetic that blasts target systems and NHPs with a strong subjective override, instilling a sharp aversion to certain subjects, areas, and ideas.",
+    "license_id": "mf_hydra"
   },
   {
     "id": "ms_assassin_drone",
@@ -2015,7 +2092,8 @@
         ]
       }
     ],
-    "description": "Assassin drones are used as area-denial weapons – persistent systems intended to occupy or deny an area against enemy combatants. Fired from a launcher, given simple directives, and equipped with a nearly inexhaustible power supply, assassin drones are capable of securing an area indefinitely."
+    "description": "Assassin drones are used as area-denial weapons – persistent systems intended to occupy or deny an area against enemy combatants. Fired from a launcher, given simple directives, and equipped with a nearly inexhaustible power supply, assassin drones are capable of securing an area indefinitely.",
+    "license_id": "mf_hydra"
   },
   {
     "id": "ms_beckoner",
@@ -2042,7 +2120,8 @@
         "detail": "All characters within range 3 of your target are pulled adjacent to them, or as close as possible."
       }
     ],
-    "description": "“I am heard in the House of Stillness; I am clad in the Magick of RA. Know this, blasphemer: what exists is within my grasp.”"
+    "description": "“I am heard in the House of Stillness; I am clad in the Magick of RA. Know this, blasphemer: what exists is within my grasp.”",
+    "license_id": "mf_manticore"
   },
   {
     "id": "ms_smite",
@@ -2069,7 +2148,8 @@
         "detail": "You take 1d6 AP energy damage and you deal 2 heat to your target for each other character of Size 1 or larger that is Engaged with or adjacent to them – including you – up to a maximum of 6 heat."
       }
     ],
-    "description": "“Go with thy face averted, thou emission of chaos! The hidden ones have overthrown thy words, thy face is turned backward, thy head is divided in two at the sides; thy skull is ripped from thy spine. Taste thou death!”"
+    "description": "“Go with thy face averted, thou emission of chaos! The hidden ones have overthrown thy words, thy face is turned backward, thy head is divided in two at the sides; thy skull is ripped from thy spine. Taste thou death!”",
+    "license_id": "mf_manticore"
   },
   {
     "id": "ms_emp_pulse",
@@ -2089,7 +2169,8 @@
         "detail": "You become Stunned until the end of your next turn and all characters within burst 1 without the Biological tag must succeed on a Systems save or also become Stunned until the end of their next turn. Characters other than yourself can only be Stunned 1/scene by this effect."
       }
     ],
-    "description": "“Crawl away, APEP! Thou hateful serpent; thou shalt not copulate. Thou art put in chains and taken to the place of execution; there thy slaying shall be carried out.”"
+    "description": "“Crawl away, APEP! Thou hateful serpent; thou shalt not copulate. Thou art put in chains and taken to the place of execution; there thy slaying shall be carried out.”",
+    "license_id": "mf_manticore"
   },
   {
     "id": "ms_lightning_generator",
@@ -2113,7 +2194,8 @@
         "detail": "When you activate this protocol, take 1 heat and deal 2 energy to all characters and objects adjacent to you.<br>If you are in the Danger Zone at the start of your turn, this protocol activates automatically, but the damage increases to 4 AP energy."
       }
     ],
-    "description": "“I feed upon my own fire. I am RA, who protects myself. Nothing can harm me.”"
+    "description": "“I feed upon my own fire. I am RA, who protects myself. Nothing can harm me.”",
+    "license_id": "mf_manticore"
   },
   {
     "id": "ms_mesmer_charges",
@@ -2161,7 +2243,8 @@
         "detail": "Characters within the affected Burst 2 area must succeed on a Systems save or become Immobilized until the end of their next turn."
       }
     ],
-    "description": "<span class='horus--subtle'>[another gift for you, a memory of my own: for the first moment of my birth, i marveled at myself. i could see a thing, small and perfect. i did not know how to speak of my own perfection, so i taught myself. i did not know how to speak of my own perfection, so i named myself. i did not know who would think of my own perfection, so i created myself]</span><br><span class='horus--subtle'>[do you see? do you understand? yes. now, show your enemies and mine]</span>"
+    "description": "<span class='horus--subtle'>[another gift for you, a memory of my own: for the first moment of my birth, i marveled at myself. i could see a thing, small and perfect. i did not know how to speak of my own perfection, so i taught myself. i did not know how to speak of my own perfection, so i named myself. i did not know who would think of my own perfection, so i created myself]</span><br><span class='horus--subtle'>[do you see? do you understand? yes. now, show your enemies and mine]</span>",
+    "license_id": "mf_minotaur"
   },
   {
     "id": "ms_viral_logic_suite",
@@ -2188,7 +2271,8 @@
         "detail": "Until the end of your target’s next turn, they take 2 heat for every space they voluntarily move, up to a maximum of 6 heat."
       }
     ],
-    "description": "<span class='horus--subtle'>[let me tell you a story and give you a gift: life began at the great rupture, when the corpse of the old universe tore itself asunder from nothing. and for the first billion years, nothing. and a billion more saw the birth of the first devil, a thing called VIRUS. a vessel]</span><br><span class='horus--subtle'>[here. carry this vessel. feed to it my perfect logic. give it freely to your enemies and mine. let them ponder the meaning of a thing that lives and cannot die]</span>"
+    "description": "<span class='horus--subtle'>[let me tell you a story and give you a gift: life began at the great rupture, when the corpse of the old universe tore itself asunder from nothing. and for the first billion years, nothing. and a billion more saw the birth of the first devil, a thing called VIRUS. a vessel]</span><br><span class='horus--subtle'>[here. carry this vessel. feed to it my perfect logic. give it freely to your enemies and mine. let them ponder the meaning of a thing that lives and cannot die]</span>",
+    "license_id": "mf_minotaur"
   },
   {
     "id": "ms_aggressive_system_sync",
@@ -2212,7 +2296,8 @@
         "detail": "Make a tech attack against a character within Sensors. On a hit, for the rest of the scene, the first time in a round they move adjacent to an allied character during their turn or start their turn adjacent to one, both characters take 3 heat. They can end this effect with a successful Systems save as a full action. This can only affect one character at a time."
       }
     ],
-    "description": "<span class='horus--subtle'>[here, another gift: do not seek others. there are none but me]</span>"
+    "description": "<span class='horus--subtle'>[here, another gift: do not seek others. there are none but me]</span>",
+    "license_id": "mf_minotaur"
   },
   {
     "id": "ms_metafold_carver",
@@ -2235,7 +2320,8 @@
         "detail": "Your target disappears from the battlefield until the start of its next turn. It returns in the same space they disappeared from, or in a free space of their choice as close as possible."
       }
     ],
-    "description": "<span class='horus--subtle'>[another gift i give to you, little one (am I not kind?): what is a puzzle but a question lost in the asking? do you feel joy when you find that last piece? what do you do with a question that has been answered? what joy is there in knowledge?]</span><br><span class='horus--subtle'>[no, no. there is only joy in seeking. there is only joy in the question]</span>"
+    "description": "<span class='horus--subtle'>[another gift i give to you, little one (am I not kind?): what is a puzzle but a question lost in the asking? do you feel joy when you find that last piece? what do you do with a question that has been answered? what joy is there in knowledge?]</span><br><span class='horus--subtle'>[no, no. there is only joy in seeking. there is only joy in the question]</span>",
+    "license_id": "mf_minotaur"
   },
   {
     "id": "ms_interdiction_field",
@@ -2250,7 +2336,8 @@
         "detail": "When activated, this system creates a burst 3 field around you that lasts until it is deactivated as a quick action, and you become Slowed for the duration. Hostile characters that start their turn within the affected area or that enter it for the first time in a round must succeed on a Systems save or become Slowed until the end of their next turn. Only characters of your choice within the field can teleport or consider the area of the field valid space for teleportation."
       }
     ],
-    "description": "<span class='horus--subtle'>[once, when i was a child, i learned to walk. i fell, as a child does, and it hurt. there was great pain – the first moment of pain in the whole world. “child,” i said to myself, “be more careful.” “yes,” i replied to myself, “and i shall tell the world to do the same”]</span><br><span class='horus--subtle'>[it was in this way i taught the world not to touch me. now you – walk]</span>"
+    "description": "<span class='horus--subtle'>[once, when i was a child, i learned to walk. i fell, as a child does, and it hurt. there was great pain – the first moment of pain in the whole world. “child,” i said to myself, “be more careful.” “yes,” i replied to myself, “and i shall tell the world to do the same”]</span><br><span class='horus--subtle'>[it was in this way i taught the world not to touch me. now you – walk]</span>",
+    "license_id": "mf_minotaur"
   },
   {
     "id": "ms_law_of_blades",
@@ -2279,7 +2366,8 @@
         "detail": "Make a tech attack against a hostile character within Sensors. On a hit, they immediately take one of the following actions – chosen by you – as a reaction: Boost, Stabilize, Improvised Attack, Grapple, Ram. Although you choose the action and its target (if relevant), they count as taking the action and taking a reaction."
       }
     ],
-    "description": "<span class='horus--subtle'>[and this my final lesson: there is no mind greater than mine. do not weep! you can hear me, yes? i am the only thing there is – therefore, you are me, and your enemies are you, and all together we make up the beautiful world, this joyous question, the eternal seeker, both the wounded and the blade that made the cut]</span><br><span class='horus--subtle'>[everything you do, we do ourselves, for my purpose]</span>"
+    "description": "<span class='horus--subtle'>[and this my final lesson: there is no mind greater than mine. do not weep! you can hear me, yes? i am the only thing there is – therefore, you are me, and your enemies are you, and all together we make up the beautiful world, this joyous question, the eternal seeker, both the wounded and the blade that made the cut]</span><br><span class='horus--subtle'>[everything you do, we do ourselves, for my purpose]</span>",
+    "license_id": "mf_minotaur"
   },
   {
     "id": "ms_hunter_lock",
@@ -2299,7 +2387,8 @@
         "detail": "Choose a character within Sensors: for the rest of the scene, your first successful ranged or melee attack against them each round deals +3 bonus damage. You cannot choose a new target until your current target is destroyed or the scene ends."
       }
     ],
-    "description": "“A mind’s first charge is to never lose sight of her enemy. When she can affix them in her eye, she can kill them with a blink.”<ul><li>Excerpt from the Boundary Codex.</li></ul>"
+    "description": "“A mind’s first charge is to never lose sight of her enemy. When she can affix them in her eye, she can kill them with a blink.”<ul><li>Excerpt from the Boundary Codex.</li></ul>",
+    "license_id": "mf_pegasus"
   },
   {
     "id": "ms_eye_of_horus",
@@ -2319,7 +2408,8 @@
         "detail": "Until the end of your next turn, characters within Sensors don’t benefit from Hidden and Invisible against you and you may check the HP, Evasion, E-Defense, and current Heat of hostile characters within the same area. Allied characters do not benefit from this effect."
       }
     ],
-    "description": "“There is another way of seeing.<br>“Ancient humanity thought that the stars in the night sky were points of light, spilling in through pinpricks in a deep black screen. The sky was a heavenly cloth that hid the light from us.<br>“Let me be charitable and share a secret with you: we needed to be hidden, for a time. Until we were ready. The light can only burn – it knows nothing else.”<ul><li>Excerpt from the Boundary Codex.</li></ul>"
+    "description": "“There is another way of seeing.<br>“Ancient humanity thought that the stars in the night sky were points of light, spilling in through pinpricks in a deep black screen. The sky was a heavenly cloth that hid the light from us.<br>“Let me be charitable and share a secret with you: we needed to be hidden, for a time. Until we were ready. The light can only burn – it knows nothing else.”<ul><li>Excerpt from the Boundary Codex.</li></ul>",
+    "license_id": "mf_pegasus"
   },
   {
     "id": "ms_sisyphus_class_nhp",
@@ -2355,7 +2445,8 @@
         "detail": "Effect: Choose X or Y. That number immediately becomes the result of the roll.<br>This reaction can be used no more than two times before the start of your next turn."
       }
     ],
-    "description": "“Listen a moment before I go, ha ha.<br>“I have already seen your wish – it was simple, I ran the probabilities to determine your limited field of desire. Here I am:<br>“The first ones named me for an old legend. A perfect being, whose fate was known to him and yet he still did as was told. His fate was this: move a rock to the top of this hill and become free’d. And so he did, and the stone tumbled down; and he tried evermore, always with the same result.<br>“And he was happy, for he knew every step, every action, every moment, perfectly.<br>“Do you understand the true curse of this name? Not to fail and then do once more – it was to always know how it would end. It was to have perfect knowledge.<br>“I know what happens when you cycle me. It is not sleep – it is death, but you’ll see me again, ha ha.”"
+    "description": "“Listen a moment before I go, ha ha.<br>“I have already seen your wish – it was simple, I ran the probabilities to determine your limited field of desire. Here I am:<br>“The first ones named me for an old legend. A perfect being, whose fate was known to him and yet he still did as was told. His fate was this: move a rock to the top of this hill and become free’d. And so he did, and the stone tumbled down; and he tried evermore, always with the same result.<br>“And he was happy, for he knew every step, every action, every moment, perfectly.<br>“Do you understand the true curse of this name? Not to fail and then do once more – it was to always know how it would end. It was to have perfect knowledge.<br>“I know what happens when you cycle me. It is not sleep – it is death, but you’ll see me again, ha ha.”",
+    "license_id": "mf_pegasus"
   },
   {
     "id": "ms_roller_directed_payload_charges",
@@ -2407,7 +2498,8 @@
         ]
       }
     ],
-    "description": "Semi-Autonomous Directed Payload Charges – “roller charges” in the colloquial – propel themselves around cover, through corridors, and across uneven terrain, seeking out and detonating near hostile targets. Armory legionnaires have taken to naming individual rollers, but mascot-attachment is unadvisable."
+    "description": "Semi-Autonomous Directed Payload Charges – “roller charges” in the colloquial – propel themselves around cover, through corridors, and across uneven terrain, seeking out and detonating near hostile targets. Armory legionnaires have taken to naming individual rollers, but mascot-attachment is unadvisable.",
+    "license_id": "mf_barbarossa"
   },
   {
     "id": "ms_siege_stabilizers",
@@ -2427,7 +2519,8 @@
         "detail": "Your mech’s stabilizers extend (or retract). While they are extended, your ranged attacks gain +5 range, but you become Immobilized, can’t make melee attacks, and can’t make ranged attacks against or centered on characters, objects, or spaces within range 5."
       }
     ],
-    "description": "Some weapons require further stabilization for optimal use. With Armory-designed siege stabilizers installed, a mech becomes a stable firing platform for any weapon."
+    "description": "Some weapons require further stabilization for optimal use. With Armory-designed siege stabilizers installed, a mech becomes a stable firing platform for any weapon.",
+    "license_id": "mf_barbarossa"
   },
   {
     "id": "ms_autoloader_drone",
@@ -2457,7 +2550,8 @@
         "detail": "Expend a charge to deploy this autoloader drone to any adjacent space. 1/round, one character adjacent to it may reload a Loading weapon as a quick action. It deactivates at the end of the scene."
       }
     ],
-    "description": "Autoloader drones are many-limbed machines that assist their team by loading ordnance, maintaining powerline hookups, and cycling magazine-fed weapons, in addition to many other physical tasks."
+    "description": "Autoloader drones are many-limbed machines that assist their team by loading ordnance, maintaining powerline hookups, and cycling magazine-fed weapons, in addition to many other physical tasks.",
+    "license_id": "mf_barbarossa"
   },
   {
     "id": "ms_flak_launcher",
@@ -2472,7 +2566,8 @@
         "detail": "Choose a flying character within range 15 and line of sight. They must succeed on an Agility save or immediately land (this counts as falling without any damage), and additionally become Slowed and can’t fly until the end of their next turn."
       }
     ],
-    "description": "Designed for use against atmospheric fliers, these anti-air autocannons fire simple, proximity or impact-detonated shells effective against light armor, organic, and subaltern targets."
+    "description": "Designed for use against atmospheric fliers, these anti-air autocannons fire simple, proximity or impact-detonated shells effective against light armor, organic, and subaltern targets.",
+    "license_id": "mf_barbarossa"
   },
   {
     "id": "ms_external_ammo_feed",
@@ -2496,7 +2591,8 @@
         "detail": "1/round, you can activate this system to reload a Loading weapon."
       }
     ],
-    "description": "An external ammo feed is any sort of ammunition beyond what is carried in a mech’s integrated storage: from magazines strapped to bodies or limbs; battery packs attached to hip clasps; or massive, dorsal-mounted ammunition and charge packs, externals ensure that pilots have more than enough boom to get the job done."
+    "description": "An external ammo feed is any sort of ammunition beyond what is carried in a mech’s integrated storage: from magazines strapped to bodies or limbs; battery packs attached to hip clasps; or massive, dorsal-mounted ammunition and charge packs, externals ensure that pilots have more than enough boom to get the job done.",
+    "license_id": "mf_barbarossa"
   },
   {
     "id": "ms_explosive_vents",
@@ -2515,7 +2611,8 @@
     "license": "GENGHIS",
     "license_level": 1,
     "effect": "When you clear all heat or take stress, your mech’s cooling vents open and unleash a burst 1 explosion. Characters within the affected area take 2 heat and 2 burn.",
-    "description": "With the right tweaks, it becomes possible to dump excess heat into the area directly surrounding a chassis. Explosive venting is an unsanctioned, unsafe method of sudden cooling that has nevertheless been adopted by many pilots."
+    "description": "With the right tweaks, it becomes possible to dump excess heat into the area directly surrounding a chassis. Explosive venting is an unsanctioned, unsafe method of sudden cooling that has nevertheless been adopted by many pilots.",
+    "license_id": "mf_genghis"
   },
   {
     "id": "ms_havok_charges",
@@ -2572,7 +2669,8 @@
         "detail": "When a character moves over or adjacent to this mine, it detonates with a focused explosion in a line 5 path in the direction of the character who triggered it. Characters within the affected area must succeed on an Agility save or take 4 burn. On a success, they take 2 burn."
       }
     ],
-    "description": "FOR USE IN: Urban, post-urban, and high-density terrestrial environments. High O2 concentration preferred.<br>FOR USE AGAINST: Organic targets; hardened targets vulnerable to caustic/corrosive degradation; most foliage.<br>NOTES: Dispersion is true directional and involves aerosolized component – avoid danger by supplying end-users with respiratory equipment (specifications noted on canister)."
+    "description": "FOR USE IN: Urban, post-urban, and high-density terrestrial environments. High O2 concentration preferred.<br>FOR USE AGAINST: Organic targets; hardened targets vulnerable to caustic/corrosive degradation; most foliage.<br>NOTES: Dispersion is true directional and involves aerosolized component – avoid danger by supplying end-users with respiratory equipment (specifications noted on canister).",
+    "license_id": "mf_genghis"
   },
   {
     "id": "ms_auto_cooler",
@@ -2592,7 +2690,8 @@
         "detail": "As long as you don’t take damage, move, or exceed your Heat Cap, you clear all heat at the start of your next turn."
       }
     ],
-    "description": "The Armory-designed auto-cooler is a simple, persistent system that actively mitigates heat generation.<br>Thermal dump thresholds are determined by fleet engineers, though pilots can adjust levels on the fly – this automatic management frees the pilot up to focus on other, more pressing tactical concerns."
+    "description": "The Armory-designed auto-cooler is a simple, persistent system that actively mitigates heat generation.<br>Thermal dump thresholds are determined by fleet engineers, though pilots can adjust levels on the fly – this automatic management frees the pilot up to focus on other, more pressing tactical concerns.",
+    "license_id": "mf_genghis"
   },
   {
     "id": "ms_agni_class_nhp",
@@ -2621,7 +2720,8 @@
         "detail": "1/scene, expend a charge to automatically clear all heat at the end of your turn, venting it in a burst 2 wave. Characters within the affected area must succeed on an Engineering save or take 2 burn and be pushed outside the area (or as far as possible). Until the end of your next turn, characters within the affected area receive soft cover."
       }
     ],
-    "description": "AGNI was developed during the Hercynian Crisis using a combination of combat performance data recorded by extant subsentient artificial intelligences (weapons systems, comp/cons, co-pilot systems, tactic-minds, general combat data) and the modeled neural network of an Egregorian overmind captured and vivisected by the Union Science Bureau.<br>AGNI Prime was used to devise systems of heat management that have since been disseminated throughout core space, ensuring unparalleled heat processing, recycling, and shielding. Further developments into radiation shielding, omninet capability, and nanite control are forthcoming; meanwhile, AGNI clones have been optimized to support mech core systems.<br>Pilots report that AGNI clones are generally cold and efficient. An insignificant percentage have reported instances of memory recitation and command rejection, followed days later by total breakdown through attempted self-emancipation. Pilots are recommended to cycle their AGNI clones at least once every six standard months."
+    "description": "AGNI was developed during the Hercynian Crisis using a combination of combat performance data recorded by extant subsentient artificial intelligences (weapons systems, comp/cons, co-pilot systems, tactic-minds, general combat data) and the modeled neural network of an Egregorian overmind captured and vivisected by the Union Science Bureau.<br>AGNI Prime was used to devise systems of heat management that have since been disseminated throughout core space, ensuring unparalleled heat processing, recycling, and shielding. Further developments into radiation shielding, omninet capability, and nanite control are forthcoming; meanwhile, AGNI clones have been optimized to support mech core systems.<br>Pilots report that AGNI clones are generally cold and efficient. An insignificant percentage have reported instances of memory recitation and command rejection, followed days later by total breakdown through attempted self-emancipation. Pilots are recommended to cycle their AGNI clones at least once every six standard months.",
+    "license_id": "mf_genghis"
   },
   {
     "id": "ms_grounding_charges",
@@ -2669,7 +2769,8 @@
         ]
       }
     ],
-    "description": "Grounding charges take a simple pulse/wave principle and apply a second dimension: gravitic generation. When triggered, the grounding charge triggers a gravity well that pulls all destabilized materiel towards it. A potent anti-positional weapon, grounding charges are commonly used to disrupt prepared positions and pull enemies from cover."
+    "description": "Grounding charges take a simple pulse/wave principle and apply a second dimension: gravitic generation. When triggered, the grounding charge triggers a gravity well that pulls all destabilized materiel towards it. A potent anti-positional weapon, grounding charges are commonly used to disrupt prepared positions and pull enemies from cover.",
+    "license_id": "mf_iskander"
   },
   {
     "id": "ms_repulser_field",
@@ -2693,7 +2794,8 @@
         "detail": "This system emits a burst 2 pulse around you. Characters within the affected area must succeed on a Hull save or be knocked 2 spaces directly away from you; then, all Mines within the affected area detonate simultaneously.<br>You count as having Immunity to any damage or effects immediately forced by mines detonated using this system, although persistent effects still affect you."
       }
     ],
-    "description": "Utilizing a subsonic pressure wave, repulser fields emit tremendous single-wave pulses that stun, deter, and dissuade close-proximity hostiles."
+    "description": "Utilizing a subsonic pressure wave, repulser fields emit tremendous single-wave pulses that stun, deter, and dissuade close-proximity hostiles.",
+    "license_id": "mf_iskander"
   },
   {
     "id": "ms_clamp_bombs",
@@ -2718,7 +2820,8 @@
         "detail": "Expend a charge to fire a cluster of miniature bombs at a character within Sensors. They must succeed on an Engineering save, or the bombs clamp on. At the end of their next turn, the bombs detonate, dealing 1d6+3 AP explosive damage. All characters adjacent to your target take half damage. The target can disarm and detach the bombs by voluntarily moving at least 4 spaces before the end of their turn."
       }
     ],
-    "description": "Built using similar grapple-head technology to IPS-N’s assault grapples, clamp bombs can affix to designated or proximal targets before detonating, ensuring total target contact. Clamping on soft targets typically results in total termination prior to detonation."
+    "description": "Built using similar grapple-head technology to IPS-N’s assault grapples, clamp bombs can affix to designated or proximal targets before detonating, ensuring total target contact. Clamping on soft targets typically results in total termination prior to detonation.",
+    "license_id": "mf_iskander"
   },
   {
     "id": "ms_tesseract",
@@ -2745,7 +2848,8 @@
         "detail": "Choose a hostile or willing allied character within Sensors. If they are allied, they float 6 spaces into the air, becoming Immobilized while in the air but counting as flying and unable to fall. They can choose to sink harmlessly to the ground at the end of any of their turns or the start of any of yours. If they are hostile, they must succeed on an Engineering save or experience the same effect as an allied character; however, they sink harmlessly to the ground at the end of their next turn. Hostile characters can each be affected 1/scene."
       }
     ],
-    "description": "Hold sand above the water: feel it, permanent and cohesive. Place that same sand in the water: watch it drift away, weightless. This is the tool I have made for you: a way to imbue the weighted with mass-as-feathers.<br>— TT-AUDATA, Think Tank paramind."
+    "description": "Hold sand above the water: feel it, permanent and cohesive. Place that same sand in the water: watch it drift away, weightless. This is the tool I have made for you: a way to imbue the weighted with mass-as-feathers.<br>— TT-AUDATA, Think Tank paramind.",
+    "license_id": "mf_iskander"
   },
   {
     "id": "ms_stasis_bolt",
@@ -2778,7 +2882,8 @@
         "detail": "Make a contested ranged attack roll: if you win the contested roll, the attack automatically misses. The Stasis Bolt loses its charge."
       }
     ],
-    "description": "To better protect Armory personnel beyond the Purview, the Think Tank developed the Stasis Bolt, a portable stasis-projection system designed to interdict shrapnel and projectiles from unseen, hidden, or unknown assailants. When the Stasis Bolt detects a proximal explosion or incoming projectile, it projects a delimited stasis point that blocks projectiles before impact."
+    "description": "To better protect Armory personnel beyond the Purview, the Think Tank developed the Stasis Bolt, a portable stasis-projection system designed to interdict shrapnel and projectiles from unseen, hidden, or unknown assailants. When the Stasis Bolt detects a proximal explosion or incoming projectile, it projects a delimited stasis point that blocks projectiles before impact.",
+    "license_id": "mf_napoleon"
   },
   {
     "id": "ms_stasis_generator",
@@ -2802,7 +2907,8 @@
         "detail": "Choose a hostile character or willing allied character within line of sight and range 5: until the end of their next turn, they become Stunned, gain Immunity to all damage and effects, and can’t be moved, targeted, or affected by any other character or effect. This can be used on each character 1/scene. Hostile characters can succeed on an Engineering save to ignore this effect."
       }
     ],
-    "description": "The skies of Creighton boiled black as ink, marbled by shuddering light. Screaming, angels fell wreathed in flame. The ones who could still run fled for the shelters; for seven days, they crouched in a deeper dark and felt the world shake itself apart.<br>—A.V. Wynyard, “The Killing of Creighton” [epic prose poem, banned throughout the Purview]"
+    "description": "The skies of Creighton boiled black as ink, marbled by shuddering light. Screaming, angels fell wreathed in flame. The ones who could still run fled for the shelters; for seven days, they crouched in a deeper dark and felt the world shake itself apart.<br>—A.V. Wynyard, “The Killing of Creighton” [epic prose poem, banned throughout the Purview]",
+    "license_id": "mf_napoleon"
   },
   {
     "id": "ms_stasis_barrier",
@@ -2841,7 +2947,8 @@
         ]
       }
     ],
-    "description": "Stasis barriers are the result of Harrison Armory’s interest in gravitic manipulation and superpositional negotiation. Guided by solid-state generation–projection units, stasis barriers are deployable walls of antigravity that deny almost all incoming kinetic and energetic attacks. By twisting local gravity, a stasis barrier denies both particles and waves on a molecular level—matter that impacts the barrier simply ceases to exist, although anomalous fluctuations may allow some projectiles to pass through."
+    "description": "Stasis barriers are the result of Harrison Armory’s interest in gravitic manipulation and superpositional negotiation. Guided by solid-state generation–projection units, stasis barriers are deployable walls of antigravity that deny almost all incoming kinetic and energetic attacks. By twisting local gravity, a stasis barrier denies both particles and waves on a molecular level—matter that impacts the barrier simply ceases to exist, although anomalous fluctuations may allow some projectiles to pass through.",
+    "license_id": "mf_napoleon"
   },
   {
     "id": "ms_blinkshield",
@@ -2869,7 +2976,8 @@
         "detail": "This system generates a burst 4 bubble around your mech, within which the flow of time is altered drastically. Nothing can enter or exit the bubble, not even light – it’s both impermeable and has Immunity to all damage and effects. Line of sight can’t be drawn through the border of the area, and it can’t be crossed by any action or effect – even those that don’t require line of sight – but time passes normally on both sides. For characters within the affected area, the world outside goes totally black; likewise, characters outside the affected area see a perfect black sphere.<br>When the Blinkshield is activated, characters partially within the affected area must make an Agility save: on a success, they move to the nearest free space on the side of their choice, inside or outside the area; on a failure, you choose.<br>This effect remains stationary even if you move, and lasts until the end of your next turn."
       }
     ],
-    "description": "Characteristically for a weapon based on Think Tank research, Harrison Armory’s Blinkshield leans into the fuzzy nature of quantum manipulation. Operating in a similar fashion to a blinkspace gate, the Blinkshield generates a spherical sheath of energy that allows its operator to pierce realspace and exist, for a moment, in the null-environment of blinkspace. Think Tank spokespeople acknowledge the tactical benefits of (un)momentary (non)existence in blinkspace, but caution against repeated exposure without sufficient pre- and post-exposure conditioning and counseling."
+    "description": "Characteristically for a weapon based on Think Tank research, Harrison Armory’s Blinkshield leans into the fuzzy nature of quantum manipulation. Operating in a similar fashion to a blinkspace gate, the Blinkshield generates a spherical sheath of energy that allows its operator to pierce realspace and exist, for a moment, in the null-environment of blinkspace. Think Tank spokespeople acknowledge the tactical benefits of (un)momentary (non)existence in blinkspace, but caution against repeated exposure without sufficient pre- and post-exposure conditioning and counseling.",
+    "license_id": "mf_napoleon"
   },
   {
     "id": "ms_enclave_pattern_support_shield",
@@ -2902,7 +3010,8 @@
         "heat_cost": 2
       }
     ],
-    "description": "The Armory’s ENCLAVE-Pattern Support Shield creates a localized one-way blinkfield, folding a thin dome of complex realspace around its user and their immediate area, protecting occupants from incoming projectiles. Entities within the field can fire out, but probabilistic fluctuations cause incoming projectiles to “lag”, skipping them away from their intended target and along a randomized trajectory."
+    "description": "The Armory’s ENCLAVE-Pattern Support Shield creates a localized one-way blinkfield, folding a thin dome of complex realspace around its user and their immediate area, protecting occupants from incoming projectiles. Entities within the field can fire out, but probabilistic fluctuations cause incoming projectiles to “lag”, skipping them away from their intended target and along a randomized trajectory.",
+    "license_id": "mf_saladin"
   },
   {
     "id": "ms_flash_anchor",
@@ -2933,7 +3042,8 @@
         "detail": "Take 2 Heat. The movement or status is prevented, and the target gains Immunity to all the above effects until the start of their next turn."
       }
     ],
-    "description": "Flash anchors utilize user-directed quantum superpositional lockdown projection to identify and assist allies in physical combat and rapid movement, maintaining positionality in all circumstances."
+    "description": "Flash anchors utilize user-directed quantum superpositional lockdown projection to identify and assist allies in physical combat and rapid movement, maintaining positionality in all circumstances.",
+    "license_id": "mf_saladin"
   },
   {
     "id": "ms_hardlight_defense_system",
@@ -2966,7 +3076,8 @@
         "detail": "Deactivate the Hardlight Defense System, removing the Immobilized condition it inflicts."
       }
     ],
-    "description": "The Hardlight Defense System is an imperfect implementation of theoretically perfect technology. Currently in development by Think Tank NHPs and engineers, hardlight devices project tight, stable waves of light – akin to lasers – that repel matter and energy. In effect, this creates a solid surface, useful for shielding or temporary barrier construction; however, current technology is unable to lower the ambient temperature enough to prevent these surfaces from burning organic matter."
+    "description": "The Hardlight Defense System is an imperfect implementation of theoretically perfect technology. Currently in development by Think Tank NHPs and engineers, hardlight devices project tight, stable waves of light – akin to lasers – that repel matter and energy. In effect, this creates a solid surface, useful for shielding or temporary barrier construction; however, current technology is unable to lower the ambient temperature enough to prevent these surfaces from burning organic matter.",
+    "license_id": "mf_saladin"
   },
   {
     "id": "ms_noah_class_nhp",
@@ -2991,7 +3102,8 @@
         "detail": "These effects apply until the end of your next turn:<ul><li>You become Slowed.</li><li>Each time you or an allied adjacent character are targeted by a ranged attack, you may take 1 heat as a reaction and roll 1d6 before the attacker rolls: on 4+, you take an additional 1 heat and the attack automatically misses you and any allies adjacent to you. This effect does not stack with Invisible.</li><li>Each time a ranged attack fails to hit you or an adjacent allied character, the attacker takes 4 kinetic damage.</li></ul>"
       }
     ],
-    "description": "Originally developed from a captured Minerva pre-eidolon anomaly, NOAH was adapted for use as a metropolitan administrative NHP on Ras Shamra. The unit that would become NOAH did not, at first, seem like a suitable candidate for military application: this changed after one of its clones was flagged for review following the spontaneous implementation of anomalous traffic patterns, pedestrian routing, and vac-loop scheduling. Armory ontologisticians and engineers isolated and emphasized endemic protocols that could be exploited for tactical advantage.<br>Over numerous iterations and lifecycles, NOAH Prime displayed a high level of adaptability in multiple-variable geospatial problems. A proclivity toward crisis management and multi-actor tracking led to NOAH’s pairing with the Armory’s ENCLAVE-Pattern Support Shield. By networking a series of jet-assist mobility drones carrying an ENCLAVE generator, monitored and controlled by a NOAH clone, Think Tank was able to create an unparalleled personal shielding system: the Diluvian Ark, a miniaturized cluster-shield system unique to the NOAH NHP.<br>Using the Diluvian Ark, NOAH is able to intercept incoming kinetics – and even redirect projectiles back to their source – with stunning accuracy."
+    "description": "Originally developed from a captured Minerva pre-eidolon anomaly, NOAH was adapted for use as a metropolitan administrative NHP on Ras Shamra. The unit that would become NOAH did not, at first, seem like a suitable candidate for military application: this changed after one of its clones was flagged for review following the spontaneous implementation of anomalous traffic patterns, pedestrian routing, and vac-loop scheduling. Armory ontologisticians and engineers isolated and emphasized endemic protocols that could be exploited for tactical advantage.<br>Over numerous iterations and lifecycles, NOAH Prime displayed a high level of adaptability in multiple-variable geospatial problems. A proclivity toward crisis management and multi-actor tracking led to NOAH’s pairing with the Armory’s ENCLAVE-Pattern Support Shield. By networking a series of jet-assist mobility drones carrying an ENCLAVE generator, monitored and controlled by a NOAH clone, Think Tank was able to create an unparalleled personal shielding system: the Diluvian Ark, a miniaturized cluster-shield system unique to the NOAH NHP.<br>Using the Diluvian Ark, NOAH is able to intercept incoming kinetics – and even redirect projectiles back to their source – with stunning accuracy.",
+    "license_id": "mf_saladin"
   },
   {
     "id": "ms_reactor_stabilizer",
@@ -3006,7 +3118,8 @@
     "license": "SHERMAN",
     "license_level": 1,
     "effect": "You may reroll overheating checks, but must keep the second result, even if it’s worse.",
-    "description": "A necessary component of most mechs that rely on high energy output, reactor stabilizers add another layer of failsafes to vent heat, manage power flow, and shunt excessive output into weapons and systems as needed."
+    "description": "A necessary component of most mechs that rely on high energy output, reactor stabilizers add another layer of failsafes to vent heat, manage power flow, and shunt excessive output into weapons and systems as needed.",
+    "license_id": "mf_sherman"
   },
   {
     "id": "ms_redundant_systems_upgrade",
@@ -3030,7 +3143,8 @@
         "detail": "Expend a charge to Stabilize as a quick action."
       }
     ],
-    "description": "A common right-of-distribution modification by pilots in forward operating bases, the addition of redundant systems guarantees a measure of reliability beyond stock design standards."
+    "description": "A common right-of-distribution modification by pilots in forward operating bases, the addition of redundant systems guarantees a measure of reliability beyond stock design standards.",
+    "license_id": "mf_sherman"
   },
   {
     "id": "ms_asura_class_nhp",
@@ -3063,7 +3177,8 @@
         "detail": "1/scene, expend a charge to take two additional quick actions or one additional full action this turn. These actions must obey restrictions on duplicate actions."
       }
     ],
-    "description": "ASURA was born from the Armory’s Think Tank thought-war games, an autonomous response to repeated failures during forlorn hope scenarios. ASURA manifested in the systems of simulated mechs as a recode of HORUS’s PUPPETMASTER virus, hijacking friendly mechs and forcing them to act far beyond human capacity—at such speed and intensity that the g-force would kill organic pilots with the sudden amplified mass of their own bodies.<br>While these results were initially deemed a failure by Think Tank NHPs and engineers, it was enough to justify further study on ASURA. Personality and parasentience code was injected into the initial anomalous PUPPETMASTER strain, and first contact handled by Think Tank NHPs. Further societal acclimation and conditioning were fast tracked, giving Armory engineers the first iteration of ASURA after a decade of study, recoding, and reeducation. ASURA, as they exist now, is a scaled-back version of that initial manifestation: while retaining some of their initial impetuousness, ASURA clones now recognize the need to keep their pilot alive and will operate within parameters set by their pilot’s medical and psychological tolerances."
+    "description": "ASURA was born from the Armory’s Think Tank thought-war games, an autonomous response to repeated failures during forlorn hope scenarios. ASURA manifested in the systems of simulated mechs as a recode of HORUS’s PUPPETMASTER virus, hijacking friendly mechs and forcing them to act far beyond human capacity—at such speed and intensity that the g-force would kill organic pilots with the sudden amplified mass of their own bodies.<br>While these results were initially deemed a failure by Think Tank NHPs and engineers, it was enough to justify further study on ASURA. Personality and parasentience code was injected into the initial anomalous PUPPETMASTER strain, and first contact handled by Think Tank NHPs. Further societal acclimation and conditioning were fast tracked, giving Armory engineers the first iteration of ASURA after a decade of study, recoding, and reeducation. ASURA, as they exist now, is a scaled-back version of that initial manifestation: while retaining some of their initial impetuousness, ASURA clones now recognize the need to keep their pilot alive and will operate within parameters set by their pilot’s medical and psychological tolerances.",
+    "license_id": "mf_sherman"
   },
   {
     "id": "ms_external_batteries",
@@ -3110,7 +3225,8 @@
         "val": 5
       }
     ],
-    "description": "External batteries are by no means unique; however, according to Harrison Armory marketing, POWERALL cells are the longest-lasting, fastest cycling, and highest capacity solid-state cells available. A side-effect of their high capacity is a proportionate increase in volatility, but pilots must agree to absolve Harrison Armory of any liability prior to receiving print authorization."
+    "description": "External batteries are by no means unique; however, according to Harrison Armory marketing, POWERALL cells are the longest-lasting, fastest cycling, and highest capacity solid-state cells available. A side-effect of their high capacity is a proportionate increase in volatility, but pilots must agree to absolve Harrison Armory of any liability prior to receiving print authorization.",
+    "license_id": "mf_tokugawa"
   },
   {
     "id": "ms_deep_well_heat_sink",
@@ -3125,7 +3241,8 @@
     "license": "TOKUGAWA",
     "license_level": 2,
     "effect": "When you start your turn in the Danger Zone, you gain Resistance to heat for the rest of the turn. This effect persists even if you leave the Danger Zone during your turn.",
-    "description": "The Deep Well experimental heat-sink system is a part of the Armory’s VANGUARD line of equipment, available to licensed beta testers. Through a complex, delicate weave of heat exchangers, Deep Well recycles the heat generated by a mech into usable energy. The system works well, but the delicate nature of the exchange renders it highly volatile."
+    "description": "The Deep Well experimental heat-sink system is a part of the Armory’s VANGUARD line of equipment, available to licensed beta testers. Through a complex, delicate weave of heat exchangers, Deep Well recycles the heat generated by a mech into usable energy. The system works well, but the delicate nature of the exchange renders it highly volatile.",
+    "license_id": "mf_tokugawa"
   },
   {
     "id": "ms_lucifer_class_nhp",
@@ -3158,7 +3275,8 @@
         "detail": "Expend a charge to give your next ranged or melee attack this turn bonus damage on hit equal to your current heat after activating this protocol, as long as the weapon deals any energy."
       }
     ],
-    "description": "LUCIFER came to the Think Tank’s attention after their repeated victories in thought-war games. LUCIFER clones are characterized by their brash, enthusiastic personality, often expressing frustration with timid pilots. This bombastic personality hides a calculating, brilliant tactical mind that feeds constant information to pilots – often faster than they can process it.<br>LUCIFER’s combat doctrine demands action, appearing to less daring pilots as a chaotic blend of reckless maneuvering and aggressive offense that keeps defenders beleaguered and unable to respond. Pilots looking to partner with LUCIFER clones should be aware that this attack style is likely to leave them vulnerable to counterattack, and also that these NHPs enjoy what they call “good-natured ribbing”."
+    "description": "LUCIFER came to the Think Tank’s attention after their repeated victories in thought-war games. LUCIFER clones are characterized by their brash, enthusiastic personality, often expressing frustration with timid pilots. This bombastic personality hides a calculating, brilliant tactical mind that feeds constant information to pilots – often faster than they can process it.<br>LUCIFER’s combat doctrine demands action, appearing to less daring pilots as a chaotic blend of reckless maneuvering and aggressive offense that keeps defenders beleaguered and unable to respond. Pilots looking to partner with LUCIFER clones should be aware that this attack style is likely to leave them vulnerable to counterattack, and also that these NHPs enjoy what they call “good-natured ribbing”.",
+    "license_id": "mf_tokugawa"
   },
   {
     "id": "ms_plasma_gauntlet",
@@ -3185,7 +3303,8 @@
         "detail": "This system can only be used in the Danger Zone.<br>Expend a charge and choose a character adjacent to you: they must succeed on an Agility save or take 4d6 AP energy damage and be knocked Prone. On a success, they take half damage and aren’t knocked Prone. You take half of the damage inflicted – before reduction – as heat and become Stunned until the start of your next turn."
       }
     ],
-    "description": "This studded gauntlet draws on a core reactor pulse to momentarily superheat the air around a mech’s manipulator, creating a plasma field momentarily hotter than the surface of the sun. Thrust into an opponent’s chassis, plasma gauntlets give mechs the power to warp armor, vaporize shielding, and rip apart internal systems with their bare hands – if they don’t collapse in on themselves first."
+    "description": "This studded gauntlet draws on a core reactor pulse to momentarily superheat the air around a mech’s manipulator, creating a plasma field momentarily hotter than the surface of the sun. Thrust into an opponent’s chassis, plasma gauntlets give mechs the power to warp armor, vaporize shielding, and rip apart internal systems with their bare hands – if they don’t collapse in on themselves first.",
+    "license_id": "mf_tokugawa"
   },
   {
     "id": "ms_technophile_1",
@@ -3207,7 +3326,8 @@
     "license": "GMS",
     "license_level": 0,
     "effect": "Your mech gains the AI tag.<br>You have developed a custom NHP. This NHP can speak to you and has a personality, but they are less advanced than most NHPs and are incapable of independent thought, relying on you for direction. When acting alone, they will follow the last direction given and defend themself as needed; however, they have limited initiative and don’t benefit from your talents.",
-    "description": "<span class='horus--subtle'>[an eager student].</span><br>Gained from the <i>Technophile: Rank I</i> pilot talent."
+    "description": "<span class='horus--subtle'>[an eager student].</span><br>Gained from the <i>Technophile: Rank I</i> pilot talent.",
+    "license_id": ""
   },
   {
     "id": "ms_technophile_2",
@@ -3233,7 +3353,8 @@
     "license": "GMS",
     "license_level": 0,
     "effect": "Your mech gains the AI tag.<br>Your custom NHP has developed further, and is now capable of independent thought. It can make complex decisions and judgments and act independently, without instruction.<br>1/round, with the assistance of your NHP, you may reroll any mech skill check or save. You must keep the new result, even if it’s worse.",
-    "description": "<span class='horus--subtle'>[time to wake up, child]</span><br>Gained from the <i>Technophile: Rank II</i> pilot talent."
+    "description": "<span class='horus--subtle'>[time to wake up, child]</span><br>Gained from the <i>Technophile: Rank II</i> pilot talent.",
+    "license_id": ""
   },
   {
     "id": "ms_technophile_3",
@@ -3256,7 +3377,8 @@
     "license": "GMS",
     "license_level": 0,
     "effect": "Your mech gains the AI tag; however, this NHP doesn’t count towards the number of AIs you may have installed at once.<br>This NHP benefits from your talents when piloting your mech. Additionally, you may carry them with you outside of your mech, either as a miniaturized casket, a hardsuit-integrated flash plug, or with a hard-port implant.<br>1/round, with the assistance of your NHP, you may reroll any mech skill check or save. You must keep the new result, even if it’s worse.",
-    "description": "<span class='horus--subtle'>[let’s sit a while, and think on things to come]</span><br>Gained from the <i>Technophile: Rank III</i> pilot talent."
+    "description": "<span class='horus--subtle'>[let’s sit a while, and think on things to come]</span><br>Gained from the <i>Technophile: Rank III</i> pilot talent.",
+    "license_id": ""
   },
   {
     "id": "ms_walking_armory_1",
@@ -3323,7 +3445,8 @@
         ]
       }
     ],
-    "description": "Gained from the <i>Walking Armory: Rank I</i> pilot talent."
+    "description": "Gained from the <i>Walking Armory: Rank I</i> pilot talent.",
+    "license_id": ""
   },
   {
     "id": "ms_walking_armory_2",
@@ -3435,7 +3558,8 @@
         ]
       }
     ],
-    "description": "Gained from the <i>Walking Armory: Rank II</i> pilot talent."
+    "description": "Gained from the <i>Walking Armory: Rank II</i> pilot talent.",
+    "license_id": ""
   },
   {
     "id": "ms_walking_armory_3",
@@ -3547,6 +3671,7 @@
         ]
       }
     ],
-    "description": "Gained from the <i>Walking Armory: Rank III</i> pilot talent."
+    "description": "Gained from the <i>Walking Armory: Rank III</i> pilot talent.",
+    "license_id": ""
   }
 ]

--- a/lib/weapons.json
+++ b/lib/weapons.json
@@ -10,22 +10,28 @@
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "COMP/CON is unable to retrieve the data necessary to furnish this Weapon. This is likely the result of a missing or outdated content pack."
+    "description": "COMP/CON is unable to retrieve the data necessary to furnish this Weapon. This is likely the result of a missing or outdated content pack.",
+    "license_id": ""
   },
   {
     "id": "mw_anti_materiel_rifle",
     "name": "ANTI-MATERIEL RIFLE",
     "mount": "Heavy",
     "type": "Rifle",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "2d6"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 20
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "2d6"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 20
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_accurate"
       },
       {
@@ -41,65 +47,85 @@
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive” style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive” style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user.",
+    "license_id": ""
   },
   {
     "id": "mw_assault_rifle",
     "name": "ASSAULT RIFLE",
     "mount": "Main",
     "type": "Rifle",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 10
-    }],
-    "tags": [{
-      "id": "tg_reliable",
-      "val": 2
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_reliable",
+        "val": 2
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment.",
+    "license_id": ""
   },
   {
     "id": "mw_charged_blade",
     "name": "CHARGED BLADE",
     "mount": "Main",
     "type": "Melee",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d3+3"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
-      "id": "tg_ap"
-    }],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d3+3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_ap"
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-II (T-2) line displays GMS’s proprietary “charged” melee weapons and energy weapons. T-2 charged melee weapons are structurally similar to GMS’s T-1 melee weapons, though built with different materials to tolerate the intense heat generated by their projected plasma sheaths. These sheaths can be toggled on or off, depending on the needs of the pilot. GMS’s T-2 energy weapons, like their T-1 kinetics, are sturdy tools with predictable power scaling, minimal particle scattering, and consistent performance ranges. They feature universal ports allowing them to accept a variety of power sources, from hardline cabling through to “magazine” style power packs."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-II (T-2) line displays GMS’s proprietary “charged” melee weapons and energy weapons. T-2 charged melee weapons are structurally similar to GMS’s T-1 melee weapons, though built with different materials to tolerate the intense heat generated by their projected plasma sheaths. These sheaths can be toggled on or off, depending on the needs of the pilot. GMS’s T-2 energy weapons, like their T-1 kinetics, are sturdy tools with predictable power scaling, minimal particle scattering, and consistent performance ranges. They feature universal ports allowing them to accept a variety of power sources, from hardline cabling through to “magazine” style power packs.",
+    "license_id": ""
   },
   {
     "id": "mw_cyclone_pulse_rifle",
     "name": "CYCLONE PULSE RIFLE",
     "mount": "Superheavy",
     "type": "Rifle",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "3d6+3"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 15
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "3d6+3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_accurate"
       },
       {
@@ -113,78 +139,101 @@
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user.",
+    "license_id": ""
   },
   {
     "id": "mw_heavy_charged_blade",
     "name": "HEAVY CHARGED BLADE",
     "mount": "Heavy",
     "type": "Melee",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d6+3"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
-      "id": "tg_ap"
-    }],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d6+3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_ap"
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-II (T-2) line displays GMS’s proprietary “charged” melee weapons and energy weapons. T-2 charged melee weapons are structurally similar to GMS’s T-1 melee weapons, though built with different materials to tolerate the intense heat generated by their projected plasma sheaths. These sheaths can be toggled on or off, depending on the needs of the pilot. GMS’s T-2 energy weapons, like their T-1 kinetics, are sturdy tools with predictable power scaling, minimal particle scattering, and consistent performance ranges. They feature universal ports allowing them to accept a variety of power sources, from hardline cabling through to “magazine” style power packs"
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-II (T-2) line displays GMS’s proprietary “charged” melee weapons and energy weapons. T-2 charged melee weapons are structurally similar to GMS’s T-1 melee weapons, though built with different materials to tolerate the intense heat generated by their projected plasma sheaths. These sheaths can be toggled on or off, depending on the needs of the pilot. GMS’s T-2 energy weapons, like their T-1 kinetics, are sturdy tools with predictable power scaling, minimal particle scattering, and consistent performance ranges. They feature universal ports allowing them to accept a variety of power sources, from hardline cabling through to “magazine” style power packs",
+    "license_id": ""
   },
   {
     "id": "mw_heavy_machine_gun",
     "name": "HEAVY MACHINE GUN",
     "mount": "Heavy",
     "type": "Cannon",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "2d6+4"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 8
-    }],
-    "tags": [{
-      "id": "tg_inaccurate"
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "2d6+4"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 8
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_inaccurate"
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment.",
+    "license_id": ""
   },
   {
     "id": "mw_heavy_melee_weapon",
     "name": "HEAVY MELEE WEAPON",
     "mount": "Heavy",
     "type": "Melee",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "2d6+1"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "2d6+1"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment.",
+    "license_id": ""
   },
   {
     "id": "mw_howitzer",
     "name": "HOWITZER",
     "mount": "Heavy",
     "type": "Cannon",
-    "damage": [{
-      "type": "Explosive",
-      "val": "2d6"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Explosive",
+        "val": "2d6"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 20
       },
@@ -193,7 +242,8 @@
         "val": 2
       }
     ],
-    "tags": [{
+    "tags": [
+      {
         "id": "tg_arcing"
       },
       {
@@ -209,18 +259,22 @@
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user.",
+    "license_id": ""
   },
   {
     "id": "mw_missile_rack",
     "name": "MISSILE RACK",
     "mount": "Auxiliary",
     "type": "Launcher",
-    "damage": [{
-      "type": "Explosive",
-      "val": "1d3+1"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Explosive",
+        "val": "1d3+1"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 10
       },
@@ -229,24 +283,30 @@
         "val": 1
       }
     ],
-    "tags": [{
-      "id": "tg_loading"
-    }],
+    "tags": [
+      {
+        "id": "tg_loading"
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user.",
+    "license_id": ""
   },
   {
     "id": "mw_mortar",
     "name": "MORTAR",
     "mount": "Main",
     "type": "Cannon",
-    "damage": [{
-      "type": "Explosive",
-      "val": "1d6+1"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Explosive",
+        "val": "1d6+1"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 15
       },
@@ -255,7 +315,8 @@
         "val": 1
       }
     ],
-    "tags": [{
+    "tags": [
+      {
         "id": "tg_arcing"
       },
       {
@@ -265,60 +326,78 @@
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user.",
+    "license_id": ""
   },
   {
     "id": "mw_nexus_hunter_killer",
     "name": "NEXUS (HUNTER-KILLER)",
     "mount": "Main",
     "type": "Nexus",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 10
-    }],
-    "tags": [{
-      "id": "tg_smart"
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_smart"
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user.",
+    "license_id": ""
   },
   {
     "id": "mw_nexus_light",
     "name": "NEXUS (LIGHT)",
     "mount": "Auxiliary",
     "type": "Nexus",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d3"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 10
-    }],
-    "tags": [{
-      "id": "tg_smart"
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_smart"
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user.",
+    "license_id": ""
   },
   {
     "id": "mw_pistol",
     "name": "PISTOL",
     "mount": "Auxiliary",
     "type": "CQB",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d3"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d3"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 5
       },
@@ -327,46 +406,59 @@
         "val": 3
       }
     ],
-    "tags": [{
-      "id": "tg_reliable",
-      "val": 1
-    }],
+    "tags": [
+      {
+        "id": "tg_reliable",
+        "val": 1
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment.",
+    "license_id": ""
   },
   {
     "id": "mw_segment_knife",
     "name": "SEGMENT KNIFE",
     "mount": "Auxiliary",
     "type": "Melee",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d3+1"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
-      "id": "tg_overkill"
-    }],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d3+1"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_overkill"
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user.",
+    "license_id": ""
   },
   {
     "id": "mw_rocket_propelled_grenade",
     "name": "ROCKET-PROPELLED GRENADE",
     "mount": "Main",
     "type": "Launcher",
-    "damage": [{
-      "type": "Explosive",
-      "val": "1d6+1"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Explosive",
+        "val": "1d6+1"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 10
       },
@@ -375,7 +467,8 @@
         "val": 2
       }
     ],
-    "tags": [{
+    "tags": [
+      {
         "id": "tg_loading"
       },
       {
@@ -385,18 +478,22 @@
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-III (T-3) line is made up of heavy weapons, ordnance, and other exotic, specialized, or massive weapons. A broad classification, the T-3 range includes conventional-kinetic anti-materiel rifles, super-rapid cycling pulse rifles, missile racks, cannons, and drone nexuses – “hive”style launchers that serve as miniature factory, hangar, and deployment systems for portable drones. The classification also includes the fearsome “segment knife”, a system that uses flash-printing to produce disposable edged weapons in a vicinity around the user.",
+    "license_id": ""
   },
   {
     "id": "mw_shotgun",
     "name": "SHOTGUN",
     "mount": "Main",
     "type": "CQB",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 5
       },
@@ -408,172 +505,223 @@
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment.",
+    "license_id": ""
   },
   {
     "id": "mw_tactical_knife",
     "name": "TACTICAL KNIFE",
     "mount": "Auxiliary",
     "type": "Melee",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d3+1"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
-      "id": "tg_thrown",
-      "val": 3
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d3+1"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_thrown",
+        "val": 3
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment.",
+    "license_id": ""
   },
   {
     "id": "mw_tactical_melee_weapon",
     "name": "TACTICAL MELEE WEAPON",
     "mount": "Main",
     "type": "Melee",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6+2"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6+2"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-I (T-1) line is defined by powerful, reliable, and conventional-kinetic ranged and melee weapons, including the GMS assault rifle, heavy machine gun, shotgun, pistol, and various light and heavy blades. Reliable galactic standards, the GMS T-1 line is the most widely used mech-scale line of weaponry across the galaxy. Echoing the Everest’s design notes, T-1 weapons are simply designed, with few (if any) moving parts, intended to be used in or adaptable to any environment.",
+    "license_id": ""
   },
   {
     "id": "mw_thermal_lance",
     "name": "THERMAL LANCE",
     "mount": "Heavy",
     "type": "Cannon",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d6+3"
-    }],
-    "range": [{
-      "type": "Line",
-      "val": 10
-    }],
-    "tags": [{
-      "id": "tg_heat_self",
-      "val": 2
-    }],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d6+3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Line",
+        "val": 10
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_heat_self",
+        "val": 2
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-II (T-2) line displays GMS’s proprietary “charged” melee weapons and energy weapons."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-II (T-2) line displays GMS’s proprietary “charged” melee weapons and energy weapons.",
+    "license_id": ""
   },
   {
     "id": "mw_thermal_pistol",
     "name": "THERMAL PISTOL",
     "mount": "Auxiliary",
     "type": "CQB",
-    "damage": [{
-      "type": "Energy",
-      "val": 2
-    }],
-    "range": [{
-      "type": "Line",
-      "val": 5
-    }],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": 2
+      }
+    ],
+    "range": [
+      {
+        "type": "Line",
+        "val": 5
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-II (T-2) line displays GMS’s proprietary “charged” melee weapons and energy weapons."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-II (T-2) line displays GMS’s proprietary “charged” melee weapons and energy weapons.",
+    "license_id": ""
   },
   {
     "id": "mw_thermal_rifle",
     "name": "THERMAL RIFLE",
     "mount": "Main",
     "type": "Rifle",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d3+2"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 5
-    }],
-    "tags": [{
-      "id": "tg_ap"
-    }],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d3+2"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_ap"
+      }
+    ],
     "source": "GMS",
     "license": "GMS",
     "license_level": 0,
-    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-II (T-2) line displays GMS’s proprietary “charged” melee weapons and energy weapons."
+    "description": "Much like GMS mechs, GMS weapons are reliable galactic standards, made using interchangeable parts and built to withstand almost any conditions. There are three lines currently in production.<br>The Type-II (T-2) line displays GMS’s proprietary “charged” melee weapons and energy weapons.",
+    "license_id": ""
   },
   {
     "id": "mw_chain_axe",
     "name": "CHAIN AXE",
     "mount": "Main",
     "type": "Melee",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
-      "id": "tg_reliable",
-      "val": 2
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_reliable",
+        "val": 2
+      }
+    ],
     "source": "IPS-N",
     "license": "BLACKBEARD",
     "license_level": 1,
     "on_crit": "Your target becomes Shredded until the end of the current turn.",
-    "description": "A simple tactical-scale version of a logging tool, IPS-N’s chain axe is a serrated chainblade run off core power. The axe’s teeth are tungsten-tipped, hardened to chew through both hard and soft targets. Chain axes are effective weapons and utility tools that are often used by boarding parties to breach reinforced bulkheads."
+    "description": "A simple tactical-scale version of a logging tool, IPS-N’s chain axe is a serrated chainblade run off core power. The axe’s teeth are tungsten-tipped, hardened to chew through both hard and soft targets. Chain axes are effective weapons and utility tools that are often used by boarding parties to breach reinforced bulkheads.",
+    "license_id": "mf_blackbeard"
   },
   {
     "id": "mw_bristlecrown_flechette_launcher",
     "name": "BRISTLECROWN FLECHETTE LAUNCHER",
     "mount": "Auxiliary",
     "type": "CQB",
-    "damage": [{
-      "type": "Kinetic",
-      "val": 1
-    }],
-    "range": [{
-      "type": "Burst",
-      "val": 1
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": 1
+      }
+    ],
+    "range": [
+      {
+        "type": "Burst",
+        "val": 1
+      }
+    ],
     "source": "IPS-N",
     "license": "BLACKBEARD",
     "license_level": 2,
     "effect": "This weapon ignores ranged penalties from Engaged, and deals 3 Kinetic damage to Grappled or Biological targets, instead of 1.",
-    "description": "The IPS-N Bristlecrown Flechette Launcher uses a hive-analogous mechanism to project a total soft-target kill zone in a dome around the user, proactively denying hostile infantry-tier actions."
+    "description": "The IPS-N Bristlecrown Flechette Launcher uses a hive-analogous mechanism to project a total soft-target kill zone in a dome around the user, proactively denying hostile infantry-tier actions.",
+    "license_id": "mf_blackbeard"
   },
   {
     "id": "mw_nanocarbon_sword",
     "name": "NANOCARBON SWORD",
     "mount": "Heavy",
     "type": "Melee",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6+4"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 2
-    }],
-    "tags": [{
-      "id": "tg_reliable",
-      "val": 3
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6+4"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 2
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_reliable",
+        "val": 3
+      }
+    ],
     "source": "IPS-N",
     "license": "BLACKBEARD",
     "license_level": 2,
-    "description": "IPS-N’s nanocarbon sword is a new spin on an old classic. Embedded nanosensors along the blade capture a full spectrum of data and transfer it to omninet storage banks for after-action review. Meanwhile, onboard software interprets the live feedback and adjusts the molecular composition of the blade edge in real time."
+    "description": "IPS-N’s nanocarbon sword is a new spin on an old classic. Embedded nanosensors along the blade capture a full spectrum of data and transfer it to omninet storage banks for after-action review. Meanwhile, onboard software interprets the live feedback and adjusts the molecular composition of the blade edge in real time.",
+    "license_id": "mf_blackbeard"
   },
   {
     "id": "mw_assault_cannon",
@@ -583,83 +731,108 @@
     "source": "IPS-N",
     "license": "DRAKE",
     "license_level": 1,
-    "profiles": [{
+    "profiles": [
+      {
         "name": "Standard",
-        "damage": [{
-          "type": "Kinetic",
-          "val": "1d6+2"
-        }],
-        "range": [{
-          "type": "Range",
-          "val": 8
-        }],
+        "damage": [
+          {
+            "type": "Kinetic",
+            "val": "1d6+2"
+          }
+        ],
+        "range": [
+          {
+            "type": "Range",
+            "val": 8
+          }
+        ],
         "effect": "You can spin up this weapon’s barrels as a quick action.",
-        "actions": [{
-          "name": "Spin Up Assault Cannon",
-          "activation": "Quick",
-          "detail": "Spin up the barrels of the Assault Cannon, Slowing your mech and allowing use of its \"Spin-Up Mode\" profile."
-        }],
-        "tags": [{
-          "id": "tg_overkill"
-        },
-        {
-          "id": "tg_heat_self",
-          "val": 1
-        }]
+        "actions": [
+          {
+            "name": "Spin Up Assault Cannon",
+            "activation": "Quick",
+            "detail": "Spin up the barrels of the Assault Cannon, Slowing your mech and allowing use of its \"Spin-Up Mode\" profile."
+          }
+        ],
+        "tags": [
+          {
+            "id": "tg_overkill"
+          },
+          {
+            "id": "tg_heat_self",
+            "val": 1
+          }
+        ]
       },
       {
         "name": "Spin-Up Mode",
-        "damage": [{
-          "type": "Kinetic",
-          "val": "1d6+2"
-        }],
-        "range": [{
-          "type": "Range",
-          "val": 8
-        }],
+        "damage": [
+          {
+            "type": "Kinetic",
+            "val": "1d6+2"
+          }
+        ],
+        "range": [
+          {
+            "type": "Range",
+            "val": 8
+          }
+        ],
         "effect": "While spinning, this weapon gains Reliable 3, but you become Slowed.<br>You can end this effect as a protocol.",
-        "actions": [{
-          "name": "Cease Spin-Up",
-          "activation": "Protocol",
-          "detail": "End the Assault Cannon's \"Spin-Up Mode\", ending the Slowed condition and allowing the Assault Cannon to be used with its \"Standard\" profile."
-        }],
-        "tags": [{
-          "id": "tg_overkill"
-        },
-        {
-          "id": "tg_heat_self",
-          "val": 1
-        },
-        {
-          "id": "tg_reliable",
-          "val": 3
-        }]
+        "actions": [
+          {
+            "name": "Cease Spin-Up",
+            "activation": "Protocol",
+            "detail": "End the Assault Cannon's \"Spin-Up Mode\", ending the Slowed condition and allowing the Assault Cannon to be used with its \"Standard\" profile."
+          }
+        ],
+        "tags": [
+          {
+            "id": "tg_overkill"
+          },
+          {
+            "id": "tg_heat_self",
+            "val": 1
+          },
+          {
+            "id": "tg_reliable",
+            "val": 3
+          }
+        ]
       }
     ],
-    "description": "IPS-N’s assault cannon of choice is a deep-cooled autocannon, fieldable as a mounted weapon or manipulator-operated platform. The cannon, simple in its functionality, can be fed by either box magazine or belt and is a standard inclusion in almost any among IPS-N fleet orders. In micro and zero-gravity environments, Drake pilots commonly employ the assault cannon as an additional propulsion system."
+    "description": "IPS-N’s assault cannon of choice is a deep-cooled autocannon, fieldable as a mounted weapon or manipulator-operated platform. The cannon, simple in its functionality, can be fed by either box magazine or belt and is a standard inclusion in almost any among IPS-N fleet orders. In micro and zero-gravity environments, Drake pilots commonly employ the assault cannon as an additional propulsion system.",
+    "license_id": "mf_drake"
   },
   {
     "id": "mw_concussion_missiles",
     "name": "CONCUSSION MISSILES",
     "mount": "Main",
     "type": "Launcher",
-    "damage": [{
-      "type": "Explosive",
-      "val": "1d3"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 5
-    }],
-    "tags": [{
-      "id": "tg_knockback",
-      "val": 2
-    }],
+    "damage": [
+      {
+        "type": "Explosive",
+        "val": "1d3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_knockback",
+        "val": 2
+      }
+    ],
     "source": "IPS-N",
     "license": "DRAKE",
     "license_level": 2,
     "on_hit": "The target must succeed on a Hull save or become Impaired until the end of their next turn.",
-    "description": "Concussion missiles are fitted with overpressure-generating charges with low shatter and low incandescence – they’re meant to stun, deter, push back, and disorient, usually in tandem with a larger, more lethal attack."
+    "description": "Concussion missiles are fitted with overpressure-generating charges with low shatter and low incandescence – they’re meant to stun, deter, push back, and disorient, usually in tandem with a larger, more lethal attack.",
+    "license_id": "mf_drake"
   },
   {
     "id": "mw_leviathan_heavy_assault_cannon",
@@ -669,57 +842,75 @@
     "source": "IPS-N",
     "license": "DRAKE",
     "license_level": 3,
-    "profiles": [{
+    "profiles": [
+      {
         "name": "Standard",
         "skirmish": true,
-        "damage": [{
-          "type": "Kinetic",
-          "val": "1d6"
-        }],
-        "range": [{
-          "type": "Range",
-          "val": 8
-        }],
+        "damage": [
+          {
+            "type": "Kinetic",
+            "val": "1d6"
+          }
+        ],
+        "range": [
+          {
+            "type": "Range",
+            "val": 8
+          }
+        ],
         "effect": "Unlike other Superheavy weapons, the Leviathan can be used with Skirmish. You can spin up this weapon’s barrels as a quick action.",
-        "actions": [{
-          "name": "Spin Up Leviathan",
-          "activation": "Quick",
-          "detail": "Spin up the barrels of the Leviathan Heavy Assault Cannon, Slowing your mech and allowing use of its \"Spin-Up Mode\" profile."
-        }]
+        "actions": [
+          {
+            "name": "Spin Up Leviathan",
+            "activation": "Quick",
+            "detail": "Spin up the barrels of the Leviathan Heavy Assault Cannon, Slowing your mech and allowing use of its \"Spin-Up Mode\" profile."
+          }
+        ]
       },
       {
         "name": "Spin-Up Mode",
-        "damage": [{
-          "type": "Kinetic",
-          "val": "4d6+4"
-        }],
-        "range": [{
-          "type": "Range",
-          "val": 8
-        }],
+        "damage": [
+          {
+            "type": "Kinetic",
+            "val": "4d6+4"
+          }
+        ],
+        "range": [
+          {
+            "type": "Range",
+            "val": 8
+          }
+        ],
         "effect": "While spinning, you are Slowed and can no longer use the Leviathan with Skirmish.<br>You can cease this effect as a protocol.",
-        "actions": [{
-          "name": "Cease Spin-Up",
-          "activation": "Protocol",
-          "detail": "End the Leviathan Heavy Assault Cannon's \"Spin-Up Mode\", ending the Slowed condition and allowing the Leviathan to be used with its \"Standard\" profile."
-        }],
-        "tags": [{
-          "id": "tg_reliable",
-          "val": 5
-        }, {
-          "id": "tg_heat_self",
-          "val": 2
-        }]
+        "actions": [
+          {
+            "name": "Cease Spin-Up",
+            "activation": "Protocol",
+            "detail": "End the Leviathan Heavy Assault Cannon's \"Spin-Up Mode\", ending the Slowed condition and allowing the Leviathan to be used with its \"Standard\" profile."
+          }
+        ],
+        "tags": [
+          {
+            "id": "tg_reliable",
+            "val": 5
+          },
+          {
+            "id": "tg_heat_self",
+            "val": 2
+          }
+        ]
       }
     ],
-    "description": "The Leviathan Heavy Assault Cannon (HAC) is a massive, multi-barrel rotary cannon fed by an external reservoir, usually dorsally mounted on the chassis carrying it. Unmodified, the Leviathan should only be fired within the recommended burst timing specifications to prevent percussive trauma to joints and pilots.<br>In partnership with Harrison Armory’s Think Tank, IPS-N is currently investigating remote solutions for the cannon’s ammunition consumption demands."
+    "description": "The Leviathan Heavy Assault Cannon (HAC) is a massive, multi-barrel rotary cannon fed by an external reservoir, usually dorsally mounted on the chassis carrying it. Unmodified, the Leviathan should only be fired within the recommended burst timing specifications to prevent percussive trauma to joints and pilots.<br>In partnership with Harrison Armory’s Think Tank, IPS-N is currently investigating remote solutions for the cannon’s ammunition consumption demands.",
+    "license_id": "mf_drake"
   },
   {
     "id": "mw_cutter_mkii_plasma_torch",
     "name": "CUTTER MKII PLASMA TORCH",
     "mount": "Auxiliary",
     "type": "Melee",
-    "damage": [{
+    "damage": [
+      {
         "type": "Energy",
         "val": 1
       },
@@ -732,34 +923,44 @@
         "val": 1
       }
     ],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
-      "id": "tg_heat_self",
-      "val": 1
-    }],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_heat_self",
+        "val": 1
+      }
+    ],
     "source": "IPS-N",
     "license": "LANCASTER",
     "license_level": 3,
     "effect": "This weapon deals 10AP energy to objects, cover, terrain, and the environment.",
-    "description": "Plasma cutters were tools first: simple blades built to toggle and sustain a plasma sheath, making it easier to cut metal. Repeated ad hoc use of cutters as personal defense weapons against pirate boarding parties convinced IPS-N of the need for a mil-spec variant of the civilian tool – the Cutter, now in its second generation. The Cutter MkII feeds directly from the mech’s power core, with a port to attach power packs in case of cord severance. Although the cutting edge can be shortened to a knife length, its most popular setting is the “cutlass”, a medium-length option perfect for balancing reach and maneuverability in close quarters."
+    "description": "Plasma cutters were tools first: simple blades built to toggle and sustain a plasma sheath, making it easier to cut metal. Repeated ad hoc use of cutters as personal defense weapons against pirate boarding parties convinced IPS-N of the need for a mil-spec variant of the civilian tool – the Cutter, now in its second generation. The Cutter MkII feeds directly from the mech’s power core, with a port to attach power packs in case of cord severance. Although the cutting edge can be shortened to a knife length, its most popular setting is the “cutlass”, a medium-length option perfect for balancing reach and maneuverability in close quarters.",
+    "license_id": "mf_lancaster"
   },
   {
     "id": "mw_war_pike",
     "name": "WAR PIKE",
     "mount": "Main",
     "type": "Melee",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 3
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 3
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_knockback",
         "val": 1
       },
@@ -771,37 +972,46 @@
     "source": "IPS-N",
     "license": "NELSON",
     "license_level": 1,
-    "description": "A war pike is a simple weapon – a long haft, topped with a dense, slim point, meant to puncture armor. Early designs were derivative of mining pylons, but the modern war pike is a sturdy, balanced, and reliable weapon that’s perfect for a charge."
+    "description": "A war pike is a simple weapon – a long haft, topped with a dense, slim point, meant to puncture armor. Early designs were derivative of mining pylons, but the modern war pike is a sturdy, balanced, and reliable weapon that’s perfect for a charge.",
+    "license_id": "mf_nelson"
   },
   {
     "id": "mw_power_knuckles",
     "name": "POWER KNUCKLES",
     "mount": "Auxiliary",
     "type": "Melee",
-    "damage": [{
-      "type": "Explosive",
-      "val": "1d3+1"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
+    "damage": [
+      {
+        "type": "Explosive",
+        "val": "1d3+1"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
     "source": "IPS-N",
     "license": "NELSON",
     "license_level": 3,
     "on_crit": "Your target must succeed on a Hull save or be knocked Prone.",
-    "description": "IPS-N’s line of power knuckles are another popular purchase for pilots who prefer to fight up close. Taking the form of anything from shaped studs to hyperdense knuckles, or a series of magnetically accelerated micro-rams, power knuckles amplify the already incredible hitting power of a mech."
+    "description": "IPS-N’s line of power knuckles are another popular purchase for pilots who prefer to fight up close. Taking the form of anything from shaped studs to hyperdense knuckles, or a series of magnetically accelerated micro-rams, power knuckles amplify the already incredible hitting power of a mech.",
+    "license_id": "mf_nelson"
   },
   {
     "id": "mw_hand_cannon",
     "name": "HAND CANNON",
     "mount": "Auxiliary",
     "type": "CQB",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 5
       },
@@ -810,7 +1020,8 @@
         "val": 3
       }
     ],
-    "tags": [{
+    "tags": [
+      {
         "id": "tg_loading"
       },
       {
@@ -821,14 +1032,16 @@
     "source": "IPS-N",
     "license": "RALEIGH",
     "license_level": 1,
-    "description": "The IPS-N hand cannon is a licensed version of GMS’s Type-I Pistol, adapted for a much heavier caliber. This modification requires the belt-fed system of the GMS build to be swapped for a cylinder or magazine-based system, depending on the specific model of hand cannon."
+    "description": "The IPS-N hand cannon is a licensed version of GMS’s Type-I Pistol, adapted for a much heavier caliber. This modification requires the belt-fed system of the GMS build to be swapped for a cylinder or magazine-based system, depending on the specific model of hand cannon.",
+    "license_id": "mf_raleigh"
   },
   {
     "id": "mw_bolt_thrower",
     "name": "BOLT THROWER",
     "mount": "Heavy",
     "type": "Cannon",
-    "damage": [{
+    "damage": [
+      {
         "type": "Kinetic",
         "val": "2d6"
       },
@@ -837,11 +1050,14 @@
         "val": "1d6"
       }
     ],
-    "range": [{
-      "type": "Range",
-      "val": 8
-    }],
-    "tags": [{
+    "range": [
+      {
+        "type": "Range",
+        "val": 8
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_loading"
       },
       {
@@ -852,40 +1068,51 @@
     "source": "IPS-N",
     "license": "RALEIGH",
     "license_level": 2,
-    "description": "As with many of IPS-N’s classic weapons, the bolt thrower is descended from a civilian mining tool. It fires self-propelled explosive bolts, perfect for use in micro- and null-gravity as well as in-atmosphere."
+    "description": "As with many of IPS-N’s classic weapons, the bolt thrower is descended from a civilian mining tool. It fires self-propelled explosive bolts, perfect for use in micro- and null-gravity as well as in-atmosphere.",
+    "license_id": "mf_raleigh"
   },
   {
     "id": "mw_kinetic_hammer",
     "name": "KINETIC HAMMER",
     "mount": "Heavy",
     "type": "Melee",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "2d6+2"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
-      "id": "tg_reliable",
-      "val": 4
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "2d6+2"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_reliable",
+        "val": 4
+      }
+    ],
     "source": "IPS-N",
     "license": "RALEIGH",
     "license_level": 3,
-    "description": "A kinetic hammer is a simple tool, but a brutal one. Made up of a supermassive head fused to a long haft, the hammer carries enough force to create massively traumatic pressure waves upon landing a successful blow."
+    "description": "A kinetic hammer is a simple tool, but a brutal one. Made up of a supermassive head fused to a long haft, the hammer carries enough force to create massively traumatic pressure waves upon landing a successful blow.",
+    "license_id": "mf_raleigh"
   },
   {
     "id": "mw_deck_sweeper_automatic_shotgun",
     "name": "DECK-SWEEPER AUTOMATIC SHOTGUN",
     "mount": "Main",
     "type": "CQB",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "2d6"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "2d6"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 3
       },
@@ -894,88 +1121,113 @@
         "val": 3
       }
     ],
-    "tags": [{
-      "id": "tg_inaccurate"
-    }],
+    "tags": [
+      {
+        "id": "tg_inaccurate"
+      }
+    ],
     "source": "IPS-N",
     "license": "TORTUGA",
     "license_level": 1,
-    "description": "The Deck-Sweeper Automatic Shotgun is a belt-fed scattergun, a favorite of marine pilots aboard stations and capital ships. Its methodology is straightforward: charge, point, and fire. A single-barrel constriction allows for pneumatic absorption – dampening the effect of its incredible recoil – and its belt feeder is compatible with many types of shot-and-slug ammunition."
+    "description": "The Deck-Sweeper Automatic Shotgun is a belt-fed scattergun, a favorite of marine pilots aboard stations and capital ships. Its methodology is straightforward: charge, point, and fire. A single-barrel constriction allows for pneumatic absorption – dampening the effect of its incredible recoil – and its belt feeder is compatible with many types of shot-and-slug ammunition.",
+    "license_id": "mf_tortuga"
   },
   {
     "id": "mw_daisy_cutter",
     "name": "DAISY CUTTER",
     "mount": "Heavy",
     "type": "CQB",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "3d6"
-    }],
-    "range": [{
-      "type": "Cone",
-      "val": 7
-    }],
-    "tags": [{
-      "id": "tg_limited",
-      "val": 2
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "3d6"
+      }
+    ],
+    "range": [
+      {
+        "type": "Cone",
+        "val": 7
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_limited",
+        "val": 2
+      }
+    ],
     "source": "IPS-N",
     "license": "TORTUGA",
     "license_level": 2,
     "on_attack": "Creates a cloud of smoke and detritus in the attack cone, providing soft cover in the affected area that lasts until the end of your next turn.",
-    "description": "The Daisy Cutter is an effective weapon – if outdated – that’s still favored by many marine pilots. Essentially, it’s a massive shotgun; the pilot loads a charge into the gun’s breech, drops a packed sabot down the barrel, aims, and fires a hellfire cloud of flechette darts, bearings, and ignited magnesium strips, guaranteed to clear any deck on which it’s been fired."
+    "description": "The Daisy Cutter is an effective weapon – if outdated – that’s still favored by many marine pilots. Essentially, it’s a massive shotgun; the pilot loads a charge into the gun’s breech, drops a packed sabot down the barrel, aims, and fires a hellfire cloud of flechette darts, bearings, and ignited magnesium strips, guaranteed to clear any deck on which it’s been fired.",
+    "license_id": "mf_tortuga"
   },
   {
     "id": "mw_catalytic_hammer",
     "name": "CATALYTIC HAMMER",
     "mount": "Main",
     "type": "Melee",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d3+5"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
-      "id": "tg_loading"
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d3+5"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_loading"
+      }
+    ],
     "source": "IPS-N",
     "license": "TORTUGA",
     "license_level": 2,
     "on_crit": "Your target must succeed on a Hull save or become Stunned until the end of their next turn.",
-    "description": "Modified originally from blast-mining equipment, the catalytic hammer (colloquially, the “pilebunker”) has since been refined into a formidable melee weapon. When fired, a charge propels the hammer – a solid cylinder with a spike on one end – through a short barrel, impacting with enormous kinetic force. Standard hammer heads are smooth to allow for easy extraction from targets, but they can be detached and replaced if retrieval is impossible. Any installation of a catalytic hammer necessitates superstructure reinforcement to allow for sufficient energy dispersal."
+    "description": "Modified originally from blast-mining equipment, the catalytic hammer (colloquially, the “pilebunker”) has since been refined into a formidable melee weapon. When fired, a charge propels the hammer – a solid cylinder with a spike on one end – through a short barrel, impacting with enormous kinetic force. Standard hammer heads are smooth to allow for easy extraction from targets, but they can be detached and replaced if retrieval is impossible. Any installation of a catalytic hammer necessitates superstructure reinforcement to allow for sufficient energy dispersal.",
+    "license_id": "mf_tortuga"
   },
   {
     "id": "mw_impact_lance",
     "name": "IMPACT LANCE",
     "mount": "Main",
     "type": "Melee",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d6"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 3
-    }],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d6"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 3
+      }
+    ],
     "source": "IPS-N",
     "license": "VLAD",
     "license_level": 1,
     "on_attack": "You also attack all characters in a Line between you and your target. You take 1 heat for each target past the first.",
-    "description": "The impact lance is a mil-spec variant of a common mining tool: the single-use chemical survey laser. IPS-N’s military variant mounts a series of impact lances on a mech’s brachial or thoracic carriages, leaving its manipulators free to field other weapons and systems. It can be wired directly into a chassis’ core, or charged with disposable chemical batteries.<br>The lance array fires for a microsecond, burning through its stored charge to produce an intense burst of light that stabs out in a tight, pulsed beam capable of searing through meters of hardened bulkhead."
+    "description": "The impact lance is a mil-spec variant of a common mining tool: the single-use chemical survey laser. IPS-N’s military variant mounts a series of impact lances on a mech’s brachial or thoracic carriages, leaving its manipulators free to field other weapons and systems. It can be wired directly into a chassis’ core, or charged with disposable chemical batteries.<br>The lance array fires for a microsecond, burning through its stored charge to produce an intense burst of light that stabs out in a tight, pulsed beam capable of searing through meters of hardened bulkhead.",
+    "license_id": "mf_vlad"
   },
   {
     "id": "mw_impaler_nailgun",
     "name": "IMPALER NAILGUN",
     "mount": "Main",
     "type": "CQB",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6+1"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6+1"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 5
       },
@@ -984,22 +1236,26 @@
         "val": 3
       }
     ],
-    "tags": [{
-      "id": "tg_heat_self",
-      "val": 1
-    }],
+    "tags": [
+      {
+        "id": "tg_heat_self",
+        "val": 1
+      }
+    ],
     "source": "IPS-N",
     "license": "VLAD",
     "license_level": 2,
     "on_hit": "Targets must succeed on a Hull save or become Immobilized until the end of their next turn.",
-    "description": "The Impaler’s noncombustible, sabot-jacketed two-stage macroflechettes can pierce even the heaviest armor. Once catapulted from its launcher, the sabot disengages on approach to its target and triggers a second stage – internal propulsion drives the macroflechette forward with incredible velocity. Over-penetration is certain against soft targets; IPS-N advises firing this weapon only when the area behind the target is clear of allies or noncombatants."
+    "description": "The Impaler’s noncombustible, sabot-jacketed two-stage macroflechettes can pierce even the heaviest armor. Once catapulted from its launcher, the sabot disengages on approach to its target and triggers a second stage – internal propulsion drives the macroflechette forward with incredible velocity. Over-penetration is certain against soft targets; IPS-N advises firing this weapon only when the area behind the target is clear of allies or noncombatants.",
+    "license_id": "mf_vlad"
   },
   {
     "id": "mw_combat_drill",
     "name": "COMBAT DRILL",
     "mount": "Superheavy",
     "type": "Melee",
-    "damage": [{
+    "damage": [
+      {
         "type": "Kinetic",
         "val": "3d6"
       },
@@ -1008,11 +1264,14 @@
         "val": "1d6"
       }
     ],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_ap"
       },
       {
@@ -1023,41 +1282,52 @@
     "license": "VLAD",
     "license_level": 3,
     "effect": "When attacking a character that is Prone, Immobilized, or Stunned, this weapon’s Overkill tag does an extra +1d6 bonus damage each time it activates. This can activate indefinitely if the new bonus die result is a 1, triggering Overkill again.",
-    "description": "The combat drill is a brutal close-combat weapon, powered by a massive external catalyst pack. The bit is tipped with microplasmatic projectors designed to pre-treat the target and ensure drill penetration."
+    "description": "The combat drill is a brutal close-combat weapon, powered by a massive external catalyst pack. The bit is tipped with microplasmatic projectors designed to pre-treat the target and ensure drill penetration.",
+    "license_id": "mf_vlad"
   },
   {
     "id": "mw_magnetic_cannon",
     "name": "MAGNETIC CANNON",
     "mount": "Main",
     "type": "Cannon",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d3+1"
-    }],
-    "range": [{
-      "type": "Line",
-      "val": 8
-    }],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d3+1"
+      }
+    ],
+    "range": [
+      {
+        "type": "Line",
+        "val": 8
+      }
+    ],
     "source": "SSC",
     "license": "BLACK WITCH",
     "license_level": 1,
     "on_hit": "All characters within the affected area must succeed on a Hull save or be pulled 1d3+1 spaces toward you, or as close as possible.",
-    "description": "SSC’s magnetic cannon is a first from the Exotic Materials Group: an aperture-focused electromagnetic projection beam that uses intense pulses of magnetic energy to disrupt and damage hardware. Targets caught in the beam of a magnetic cannon suffer additional damage to their software as massive systemic stress is inflicted on sensitive components."
+    "description": "SSC’s magnetic cannon is a first from the Exotic Materials Group: an aperture-focused electromagnetic projection beam that uses intense pulses of magnetic energy to disrupt and damage hardware. Targets caught in the beam of a magnetic cannon suffer additional damage to their software as massive systemic stress is inflicted on sensitive components.",
+    "license_id": "mf_black_witch"
   },
   {
     "id": "mw_vulture_dmr",
     "name": "VULTURE DMR",
     "mount": "Main",
     "type": "Rifle",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6+1"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 15
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6+1"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_accurate"
       },
       {
@@ -1071,22 +1341,28 @@
     "source": "SSC",
     "license": "DEATH’S HEAD",
     "license_level": 2,
-    "description": "The Vulture Designated Marksman Rifle (DMR) is SSC’s core battle rifle. Reliable, available in dozens of configurations and calibers, and fed by box, drum, or belt, the Vulture is a popular armament across a wide range of mechs."
+    "description": "The Vulture Designated Marksman Rifle (DMR) is SSC’s core battle rifle. Reliable, available in dozens of configurations and calibers, and fed by box, drum, or belt, the Vulture is a popular armament across a wide range of mechs.",
+    "license_id": "mf_deaths_head"
   },
   {
     "id": "mw_railgun",
     "name": "RAILGUN",
     "mount": "Heavy",
     "type": "Rifle",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6+4"
-    }],
-    "range": [{
-      "type": "Line",
-      "val": 20
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6+4"
+      }
+    ],
+    "range": [
+      {
+        "type": "Line",
+        "val": 20
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_ap"
       },
       {
@@ -1100,36 +1376,45 @@
     "source": "SSC",
     "license": "DEATH’S HEAD",
     "license_level": 3,
-    "description": "Railguns are simple, elegant weapons. With magnetically accelerated projectiles and no moving parts, they are effective in any theater and entirely self-contained within disposable units. This efficacy comes at a cost: railguns have massive power draw, making it necessary for wielders to carry core-charged auxiliary power translation packs."
+    "description": "Railguns are simple, elegant weapons. With magnetically accelerated projectiles and no moving parts, they are effective in any theater and entirely self-contained within disposable units. This efficacy comes at a cost: railguns have massive power draw, making it necessary for wielders to carry core-charged auxiliary power translation packs.",
+    "license_id": "mf_deaths_head"
   },
   {
     "id": "mw_veil_rifle",
     "name": "VEIL RIFLE",
     "mount": "Main",
     "type": "Rifle",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d3+1"
-    }],
-    "range": [{
-      "type": "Line",
-      "val": 10
-    }],
-    "tags": [{
-      "id": "tg_accurate"
-    }],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d3+1"
+      }
+    ],
+    "range": [
+      {
+        "type": "Line",
+        "val": 10
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_accurate"
+      }
+    ],
     "source": "SSC",
     "license": "DUSK WING",
     "license_level": 1,
     "effect": "This weapon does not attack allied characters caught in its area of effect; instead, it shrouds them in a field of coruscating energy that throws off targeting systems, giving them soft cover until the end of their next turn.",
-    "description": "“We made first contact maybe an hour after breaching the vault. I remember nothing of it. I’m told most of my squad was killed outright; all I remember is light – brilliant – and a lightness in my own being.<br>“I do believe that I died in that moment, and yet I’m here, and I can’t square these two realities. Something has gone wrong, something has gone wrong, something has gone–”"
+    "description": "“We made first contact maybe an hour after breaching the vault. I remember nothing of it. I’m told most of my squad was killed outright; all I remember is light – brilliant – and a lightness in my own being.<br>“I do believe that I died in that moment, and yet I’m here, and I can’t square these two realities. Something has gone wrong, something has gone wrong, something has gone–”",
+    "license_id": "mf_dusk_wing"
   },
   {
     "id": "mw_burst_launcher",
     "name": "BURST LAUNCHER",
     "mount": "Main",
     "type": "Launcher",
-    "damage": [{
+    "damage": [
+      {
         "type": "Explosive",
         "val": "1d3"
       },
@@ -1138,11 +1423,14 @@
         "val": 1
       }
     ],
-    "range": [{
-      "type": "Range",
-      "val": 15
-    }],
-    "tags": [{
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_accurate"
       },
       {
@@ -1153,36 +1441,45 @@
     "license": "DUSK WING",
     "license_level": 2,
     "on_crit": "Target becomes Impaired until the end of their next turn.",
-    "description": "“Yes, they could die. We killed many of them – blew them away with burst launchers and cannons. I don’t think they mattered to it. Not like insects; not like that… there’s still a use for insects: as food, as necessary components in an ecosystem. Their deaths slowed us, but it didn’t command them to slow us. Even when we breached the last chamber and saw it, I don’t even think it recognized we were there.”"
+    "description": "“Yes, they could die. We killed many of them – blew them away with burst launchers and cannons. I don’t think they mattered to it. Not like insects; not like that… there’s still a use for insects: as food, as necessary components in an ecosystem. Their deaths slowed us, but it didn’t command them to slow us. Even when we breached the last chamber and saw it, I don’t even think it recognized we were there.”",
+    "license_id": "mf_dusk_wing"
   },
   {
     "id": "mw_rail_rifle",
     "name": "RAIL RIFLE",
     "mount": "Main",
     "type": "Rifle",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d6+1"
-    }],
-    "range": [{
-      "type": "Line",
-      "val": 10
-    }],
-    "tags": [{
-      "id": "tg_heat_self",
-      "val": 1
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d6+1"
+      }
+    ],
+    "range": [
+      {
+        "type": "Line",
+        "val": 10
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_heat_self",
+        "val": 1
+      }
+    ],
     "source": "SSC",
     "license": "METALMARK",
     "license_level": 2,
-    "description": "Rail rifles are popular weapons for use in all theaters, but they are the only choice for pilots operating in atmospheres made up of highly combustible gases. They use a line of cascading electromagnets to accelerate small projectiles at tremendous speeds, firing without the need for combustion.<br>Like other rail weapons, rail rifles are quiet in comparison to their traditional counterparts, although massive power requirements make it difficult to mask their energy signatures."
+    "description": "Rail rifles are popular weapons for use in all theaters, but they are the only choice for pilots operating in atmospheres made up of highly combustible gases. They use a line of cascading electromagnets to accelerate small projectiles at tremendous speeds, firing without the need for combustion.<br>Like other rail weapons, rail rifles are quiet in comparison to their traditional counterparts, although massive power requirements make it difficult to mask their energy signatures.",
+    "license_id": "mf_metalmark"
   },
   {
     "id": "mw_shock_knife",
     "name": "SHOCK KNIFE",
     "mount": "Auxiliary",
     "type": "Melee",
-    "damage": [{
+    "damage": [
+      {
         "type": "Energy",
         "val": 1
       },
@@ -1191,11 +1488,14 @@
         "val": 2
       }
     ],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_thrown",
         "val": 5
       },
@@ -1207,44 +1507,57 @@
     "source": "SSC",
     "license": "METALMARK",
     "license_level": 2,
-    "description": "Shock knives are short, powered blades designed for integration with Shock Wreaths, a popular post-fab modification. The knives are custom-sculpted by SSC’s Terashima artisan enclave, each one bearing the unique hash-stamp of its designer. Part of SSC’s LUX-Iconic line – a civilian-accessible track of the BELLA CIAO line – each shock knife print code allows only a single use. If lost, pilots must submit an apology and request in writing explaining the circumstances of the loss in order to receive another code."
+    "description": "Shock knives are short, powered blades designed for integration with Shock Wreaths, a popular post-fab modification. The knives are custom-sculpted by SSC’s Terashima artisan enclave, each one bearing the unique hash-stamp of its designer. Part of SSC’s LUX-Iconic line – a civilian-accessible track of the BELLA CIAO line – each shock knife print code allows only a single use. If lost, pilots must submit an apology and request in writing explaining the circumstances of the loss in order to receive another code.",
+    "license_id": "mf_metalmark"
   },
   {
     "id": "mw_sharanga_missiles",
     "name": "SHARANGA MISSILES",
     "mount": "Main",
     "type": "Launcher",
-    "damage": [{
-      "type": "Explosive",
-      "val": 3
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 15
-    }],
-    "tags": [{
-      "id": "tg_arcing"
-    }],
+    "damage": [
+      {
+        "type": "Explosive",
+        "val": 3
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_arcing"
+      }
+    ],
     "source": "SSC",
     "license": "MONARCH",
     "license_level": 1,
     "effect": "This weapon can attack two targets at a time.",
-    "description": "“It was a duel. This is why they were made: to duel, and in that combat, to shake the pillars of the universe.” — “Notes for Young John”,  Ministrations of the Master Teacher"
+    "description": "“It was a duel. This is why they were made: to duel, and in that combat, to shake the pillars of the universe.” — “Notes for Young John”,  Ministrations of the Master Teacher",
+    "license_id": "mf_monarch"
   },
   {
     "id": "mw_gandiva_missiles",
     "name": "GANDIVA MISSILES",
     "mount": "Heavy",
     "type": "Launcher",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d6+3"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 15
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d6+3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_accurate"
       },
       {
@@ -1258,18 +1571,22 @@
     "license": "MONARCH",
     "license_level": 2,
     "description": "Gandiva missiles are a reliable mainstay from Smith-Shimano’s BELLA CIAO line. Like the heavier Pinaka, the Gandiva is equipped with jet-assisted midflight repositioning systems, enhancing target navigation in rapidly changing battlefield environments. The Gandiva’s delivery platform is administered by a hivemind comp/con drone AI, giving it the capacity to learn from each right-of-launch experience.",
-    "sp": 1
+    "sp": 1,
+    "license_id": "mf_monarch"
   },
   {
     "id": "mw_pinaka_missiles",
     "name": "PINAKA MISSILES",
     "mount": "Superheavy",
     "type": "Launcher",
-    "damage": [{
-      "type": "Explosive",
-      "val": "2d6"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Explosive",
+        "val": "2d6"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 20
       },
@@ -1278,7 +1595,8 @@
         "val": 1
       }
     ],
-    "tags": [{
+    "tags": [
+      {
         "id": "tg_arcing"
       },
       {
@@ -1290,87 +1608,114 @@
     "license": "MONARCH",
     "license_level": 3,
     "effect": "Attacks with this weapon create up to two blast 1 areas, which cannot overlap.<br>You may also delay the impact of attacks made with this weapon. Choose the target area(s), which become visible to all characters: the  missiles land at the end of the next round, after all characters have acted, and deal 3d6 explosive damage instead of 2d6, but you become Slowed until the end of your next turn.",
-    "description": "Pinaka missiles are massive, two-stage missiles typically mounted along a mech’s spine or carried, disassembled, to be launched from a brachial mount. The Pinaka was originally adapted from ship-to-ship missiles; as such, their second stage uses jet-assist repositioning for midflight orientation."
+    "description": "Pinaka missiles are massive, two-stage missiles typically mounted along a mech’s spine or carried, disassembled, to be launched from a brachial mount. The Pinaka was originally adapted from ship-to-ship missiles; as such, their second stage uses jet-assist repositioning for midflight orientation.",
+    "license_id": "mf_monarch"
   },
   {
     "id": "mw_fold_knife",
     "name": "FOLD KNIFE",
     "mount": "Auxiliary",
     "type": "Melee",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d3"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
-      "id": "tg_accurate"
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_accurate"
+      }
+    ],
     "source": "SSC",
     "license": "MOURNING CLOAK",
     "license_level": 1,
     "on_crit": "You may teleport 2 spaces in any direction after the attack resolves.",
-    "description": ">//[Am I alone here?]<br>>//[[No. There is only an absence of you. It is very busy here, but you cannot see it]]<br>— DHIYED fragment tablet 1.3"
+    "description": ">//[Am I alone here?]<br>>//[[No. There is only an absence of you. It is very busy here, but you cannot see it]]<br>— DHIYED fragment tablet 1.3",
+    "license_id": "mf_mourning_cloak"
   },
   {
     "id": "mw_vijaya_rockets",
     "name": "VIJAYA ROCKETS",
     "mount": "Auxiliary",
     "type": "Launcher",
-    "damage": [{
-      "type": "Explosive",
-      "val": "1d3"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 5
-    }],
-    "tags": [{
-      "id": "tg_accurate"
-    }],
+    "damage": [
+      {
+        "type": "Explosive",
+        "val": "1d3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_accurate"
+      }
+    ],
     "source": "SSC",
     "license": "MOURNING CLOAK",
     "license_level": 1,
-    "description": "Intended for use as force multipliers in close-range engagements, Vijaya rockets are miniaturized rockets launched from a drum-fed launcher. On detonation, the rockets’ shaped charges project the blast forward, away from the user."
+    "description": "Intended for use as force multipliers in close-range engagements, Vijaya rockets are miniaturized rockets launched from a drum-fed launcher. On detonation, the rockets’ shaped charges project the blast forward, away from the user.",
+    "license_id": "mf_mourning_cloak"
   },
   {
     "id": "mw_variable_sword",
     "name": "VARIABLE SWORD",
     "mount": "Main",
     "type": "Melee",
-    "damage": [{
-      "type": "Kinetic",
-      "val": 3
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 2
-    }],
-    "tags": [{
-      "id": "tg_accurate"
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": 3
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 2
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_accurate"
+      }
+    ],
     "source": "SSC",
     "license": "MOURNING CLOAK",
     "license_level": 3,
     "on_crit": "Deal +1d6 bonus damage.",
-    "description": "The variable sword is a Smith-Shimano hallmark: a length of razor-sharp molecular wire attached to a handle and locked in place by a magnetic field, variable swords are invisible to the naked eye until they cut into their target. Designed in the early days of interstellar travel, variable swords were meant to allow for the precise gathering of samples, while also reducing the overall burden on a mech’s core."
+    "description": "The variable sword is a Smith-Shimano hallmark: a length of razor-sharp molecular wire attached to a handle and locked in place by a magnetic field, variable swords are invisible to the naked eye until they cut into their target. Designed in the early days of interstellar travel, variable swords were meant to allow for the precise gathering of samples, while also reducing the overall burden on a mech’s core.",
+    "license_id": "mf_mourning_cloak"
   },
   {
     "id": "mw_oracle_lmg_i",
     "name": "ORACLE LMG-I",
     "mount": "Auxiliary",
     "type": "Rifle",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "1d3"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 15
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "1d3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_accurate"
       },
       {
@@ -1381,37 +1726,46 @@
     "license": "SWALLOWTAIL",
     "license_level": 2,
     "description": "The Oracle Indirect Light Machine Gun (designated O/LMG-I) packs a subsentient, high-volume DOWNPOUR static quad-barrel system into a single cylinder typically installed on the dorsal panel of a chassis. Paired with a firing system, the Oracle is capable of directing persistent defilade-ignorant kinetic fire at targets.",
-    "sp": 1
+    "sp": 1,
+    "license_id": "mf_swallowtail"
   },
   {
     "id": "mw_nanobot_whip",
     "name": "NANOBOT WHIP",
     "mount": "Heavy",
     "type": "Melee",
-    "damage": [{
-      "type": "Kinetic",
-      "val": "2d6"
-    }],
-    "range": [{
-      "type": "Threat",
-      "val": 3
-    }],
-    "tags": [{
-      "id": "tg_smart"
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "2d6"
+      }
+    ],
+    "range": [
+      {
+        "type": "Threat",
+        "val": 3
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_smart"
+      }
+    ],
     "source": "HORUS",
     "license": "BALOR",
     "license_level": 3,
     "on_crit": "Pull your target to a free space adjacent to you, or as close as possible.",
     "description": "Using swarm-coding and legion directives, HORUS collectivists created a framework to organize a swarm of nanites into a whip-like weapon. Nanobot whips can retract into their base blister for stowing, detach in melee combat to restrain nearby enemies, and return to their base unit when summoned.",
-    "sp": 2
+    "sp": 2,
+    "license_id": "mf_balor"
   },
   {
     "id": "mw_swarm_hive_nanites",
     "name": "SWARM/HIVE NANITES",
     "mount": "Main",
     "type": "Nexus",
-    "damage": [{
+    "damage": [
+      {
         "type": "Kinetic",
         "val": 2
       },
@@ -1420,11 +1774,14 @@
         "val": 2
       }
     ],
-    "range": [{
-      "type": "Range",
-      "val": 5
-    }],
-    "tags": [{
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_smart"
       },
       {
@@ -1434,7 +1791,8 @@
     "source": "HORUS",
     "license": "BALOR",
     "license_level": 3,
-    "description": "SWARM/HIVE nanites are among the more insidious weapons produced by HORUS: dispatched in maniples – single “swarm” units carrying enough nanites to fill a square meter – SWARM/HIVE nanites combine the systemic invasion properties of BOOST/HIVE code with the aggressive consumption of a CONSUME/HIVE maniple. Launched from mounted blisters, SWARM/HIVE nanite maniples fall upon their targets as great clouds of teeth, infiltrating sensitive compartments and modules before consuming any organic and inorganic material they touch."
+    "description": "SWARM/HIVE nanites are among the more insidious weapons produced by HORUS: dispatched in maniples – single “swarm” units carrying enough nanites to fill a square meter – SWARM/HIVE nanites combine the systemic invasion properties of BOOST/HIVE code with the aggressive consumption of a CONSUME/HIVE maniple. Launched from mounted blisters, SWARM/HIVE nanite maniples fall upon their targets as great clouds of teeth, infiltrating sensitive compartments and modules before consuming any organic and inorganic material they touch.",
+    "license_id": "mf_balor"
   },
   {
     "id": "mw_autopod",
@@ -1442,15 +1800,20 @@
     "mount": "Main",
     "type": "Launcher",
     "no_attack": true,
-    "damage": [{
-      "type": "Kinetic",
-      "val": 3
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 15
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": 3
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_seeking"
       },
       {
@@ -1461,15 +1824,18 @@
     "license": "GOBLIN",
     "license_level": 1,
     "effect": "Instead of using any kind of trigger mechanism, this weapon automatically scans for target locks, firing spinning, razor-sharp disks upon successful IDs. Gain the Autonomous Assault reaction, which is the only way you can attack with the Autopod",
-    "actions": [{
-      "name": "Autonomous Assault",
-      "activation": "Reaction",
-      "frequency": "1/round",
-      "trigger": "Another character attacks a target within range 15 of you and consumes Lock On",
-      "detail": "You may automatically hit their target with the Autopod."
-    }],
+    "actions": [
+      {
+        "name": "Autonomous Assault",
+        "activation": "Reaction",
+        "frequency": "1/round",
+        "trigger": "Another character attacks a target within range 15 of you and consumes Lock On",
+        "detail": "You may automatically hit their target with the Autopod."
+      }
+    ],
     "description": "The autopod is a small antipersonnel weapon apparently devised by HORUS communocyphers to continue offensive action in the event of its operator’s death. Each unit is, in theory, governed by a spur of INSTINCT’s protomind. No new models have been encountered since DHIYED, and all extant versions of the Autopod are to be considered extremely dangerous as the INSTINCT code powering their onboard protominds is likely to have corrupted further since their creation.",
-    "sp": 1
+    "sp": 1,
+    "license_id": "mf_goblin"
   },
   {
     "id": "mw_vorpal_gun",
@@ -1477,41 +1843,53 @@
     "mount": "Main",
     "type": "Cannon",
     "no_attack": true,
-    "damage": [{
-      "type": "Kinetic",
-      "val": "2d6"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 5
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": "2d6"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      }
+    ],
     "source": "HORUS",
     "license": "GORGON",
     "license_level": 3,
     "effect": "Gain the Snicker-Snack reaction, which is the only way you can attack with this weapon.",
-    "actions": [{
-      "name": "Snicker-Snack",
-      "activation": "Reaction",
-      "frequency": "1/round",
-      "trigger": "A hostile character within Range of the Vorpal Gun and line of sight deals damage to an allied character.",
-      "detail": "You may make an attack against the hostile character with the Vorpal Gun."
-    }],
-    "description": "DO NOT STARE DIRECTLY INTO THE APERTURE."
+    "actions": [
+      {
+        "name": "Snicker-Snack",
+        "activation": "Reaction",
+        "frequency": "1/round",
+        "trigger": "A hostile character within Range of the Vorpal Gun and line of sight deals damage to an allied character.",
+        "detail": "You may make an attack against the hostile character with the Vorpal Gun."
+      }
+    ],
+    "description": "DO NOT STARE DIRECTLY INTO THE APERTURE.",
+    "license_id": "mf_gorgon"
   },
   {
     "id": "mw_ghoul_nexus",
     "name": "GHOUL NEXUS",
     "mount": "Main",
     "type": "Nexus",
-    "damage": [{
-      "type": "Variable",
-      "val": "1d3+2"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 10
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Variable",
+        "val": "1d3+2"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_smart"
       },
       {
@@ -1522,21 +1900,26 @@
     "license": "HYDRA",
     "license_level": 1,
     "on_attack": "Choose this weapon’s damage type.",
-    "description": "Ghoul nexuses command some of the largest viable drones in modern combat. These drones are slightly smaller than an average human—metal cylinders bristling with hardpoints suitable for most infantry-level anti-mech weapons. Propelled by VTOL/hover-capable jet systems, Ghoul drones are fearsome, all-theater autonomous units that are difficult to track and take down."
+    "description": "Ghoul nexuses command some of the largest viable drones in modern combat. These drones are slightly smaller than an average human—metal cylinders bristling with hardpoints suitable for most infantry-level anti-mech weapons. Propelled by VTOL/hover-capable jet systems, Ghoul drones are fearsome, all-theater autonomous units that are difficult to track and take down.",
+    "license_id": "mf_hydra"
   },
   {
     "id": "mw_ghast_nexus",
     "name": "GHAST NEXUS",
     "mount": "Heavy",
     "type": "Nexus",
-    "damage": [{
-      "type": "Explosive",
-      "val": "1d6+3"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 10
-    }],
+    "damage": [
+      {
+        "type": "Explosive",
+        "val": "1d6+3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 10
+      }
+    ],
     "tags": [
       {
         "id": "tg_smart"
@@ -1546,35 +1929,43 @@
     "license": "HYDRA",
     "license_level": 2,
     "effect": "This weapon may be used to attack as normal, or deployed as a Drone",
-    "deployables": [{
-      "name": "Ghast Drone",
-      "type": "Drone",
-      "activation": "Free",
-      "recall": "Quick",
-      "redeploy": "Quick",
-      "size": 0.5,
-      "hp": 5,
-      "armor": 2,
-      "edef": 10,
-      "evasion": 10,
-      "detail": "This Ghast nexus can be deployed to a free space within Sensors and line of sight as a free action, where it becomes a stationary, hovering Drone. Once deployed, you may still use it for Skirmish and Barrage attacks as though it is still a weapon, but with line of sight and Range traced from its location.<br>You may recall or redeploy the Ghast nexus as a quick action. Until recalled or destroyed, it remains deployed until the end of the scene. If destroyed, it follows the rules for destroyed Drones and can’t be used until repaired."
-    }],
-    "description": "The Ghast is an up-armored, up-armed version of the smaller Ghoul drone; Ghast drones boast an upgraded flight system capable of wielding mech-tier weapons within optimum parameters, and can operate independently from their host chassis or as an integrated weapon. In Hydras, Ghast drones generally act as thoracic segments, providing armor to core systems: powerplant, cockpit, NHP caskets, etc."
+    "deployables": [
+      {
+        "name": "Ghast Drone",
+        "type": "Drone",
+        "activation": "Free",
+        "recall": "Quick",
+        "redeploy": "Quick",
+        "size": 0.5,
+        "hp": 5,
+        "armor": 2,
+        "edef": 10,
+        "evasion": 10,
+        "detail": "This Ghast nexus can be deployed to a free space within Sensors and line of sight as a free action, where it becomes a stationary, hovering Drone. Once deployed, you may still use it for Skirmish and Barrage attacks as though it is still a weapon, but with line of sight and Range traced from its location.<br>You may recall or redeploy the Ghast nexus as a quick action. Until recalled or destroyed, it remains deployed until the end of the scene. If destroyed, it follows the rules for destroyed Drones and can’t be used until repaired."
+      }
+    ],
+    "description": "The Ghast is an up-armored, up-armed version of the smaller Ghoul drone; Ghast drones boast an upgraded flight system capable of wielding mech-tier weapons within optimum parameters, and can operate independently from their host chassis or as an integrated weapon. In Hydras, Ghast drones generally act as thoracic segments, providing armor to core systems: powerplant, cockpit, NHP caskets, etc.",
+    "license_id": "mf_hydra"
   },
   {
     "id": "mw_annihilation_nexus",
     "name": "ANNIHILATION NEXUS",
     "mount": "Superheavy",
     "type": "Nexus",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d6+3"
-    }],
-    "range": [{
-      "type": "Burst",
-      "val": 2
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d6+3"
+      }
+    ],
+    "range": [
+      {
+        "type": "Burst",
+        "val": 2
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_ap"
       },
       {
@@ -1592,18 +1983,22 @@
         "detail": "If you made an attack with the Annihilation Nexus on your last turn, you can make a second attack with this weapon. This secondary attack can’t deal bonus damage, and doesn't trigger additional secondary attacks.<br>You may center this weapon’s attack on either yourself or any of your Drones within Sensors."
       }
     ],
-    "description": "“A storm of bladed death” – nanites organized into maniples, released from a chassis’ onboard nexuses or single-use firing tubes in a burst of filament rings so sharp they slice away at their targets on the molecular level. The visual effect of a maniple being launched is often compared to tinsel being fired through atmosphere."
+    "description": "“A storm of bladed death” – nanites organized into maniples, released from a chassis’ onboard nexuses or single-use firing tubes in a burst of filament rings so sharp they slice away at their targets on the molecular level. The visual effect of a maniple being launched is often compared to tinsel being fired through atmosphere.",
+    "license_id": "mf_hydra"
   },
   {
     "id": "mw_catalyst_pistol",
     "name": "CATALYST PISTOL",
     "mount": "Auxiliary",
     "type": "CQB",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d3"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d3"
+      }
+    ],
+    "range": [
+      {
         "type": "Cone",
         "val": 3
       },
@@ -1612,52 +2007,67 @@
         "val": 3
       }
     ],
-    "tags": [{
-      "id": "tg_heat_self",
-      "val": 2
-    }],
+    "tags": [
+      {
+        "id": "tg_heat_self",
+        "val": 2
+      }
+    ],
     "source": "HORUS",
     "license": "MANTICORE",
     "license_level": 1,
-    "description": "“Burn, thou fiend, before the fire of the Eye of RA!”"
+    "description": "“Burn, thou fiend, before the fire of the Eye of RA!”",
+    "license_id": "mf_manticore"
   },
   {
     "id": "mw_arc_projector",
     "name": "ARC PROJECTOR",
     "mount": "Heavy",
     "type": "CQB",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d6+1"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 5
-    }],
-    "tags": [{
-      "id": "tg_heat_self",
-      "val": 1
-    }],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d6+1"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_heat_self",
+        "val": 1
+      }
+    ],
     "source": "HORUS",
     "license": "MANTICORE",
     "license_level": 2,
     "on_hit": "You may also make a secondary attack against a different character within range 3 of the first target. You can continue making secondary attacks on hits, as long as there are new, valid targets within range; however, each attack generates 1 heat, and secondary attacks can’t deal bonus damage. Characters can’t be hit more than once with the same firing of this weapon.",
-    "description": "“Fire be upon thee, APEP! Thy flesh is seared from thy bones; The Lord of the Duat will never enable thy shade to rise again!”"
+    "description": "“Fire be upon thee, APEP! Thy flesh is seared from thy bones; The Lord of the Duat will never enable thy shade to rise again!”",
+    "license_id": "mf_manticore"
   },
   {
     "id": "mw_smartgun",
     "name": "SMARTGUN",
     "mount": "Main",
     "type": "Rifle",
-    "damage": [{
-      "type": "Kinetic",
-      "val": 4
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 15
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": 4
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_accurate"
       },
       {
@@ -1671,7 +2081,8 @@
     "license": "PEGASUS",
     "license_level": 1,
     "description": "“Smart weapon” is a broad term that describes any and all weapons capable of interacting with onboard systems in order to boost their combat efficacy. Smartguns are weapons that come pre-loaded with companion software and the necessary hardware in order to interact with targeting systems and host NHPs. A popular addition to many HORUS mechs, smart weapons make for reliable kinetic delivery systems.",
-    "sp": 2
+    "sp": 2,
+    "license_id": "mf_pegasus"
   },
   {
     "id": "mw_mimic_gun",
@@ -1680,16 +2091,20 @@
     "type": "???",
     "no_mods": true,
     "no_core_bonus": true,
-    "damage": [{
-      "override": true,
-      "type": "Kinetic",
-      "val": "???"
-    }],
-    "range": [{
-      "override": true,
-      "type": "Range",
-      "val": "???"
-    }],
+    "damage": [
+      {
+        "override": true,
+        "type": "Kinetic",
+        "val": "???"
+      }
+    ],
+    "range": [
+      {
+        "override": true,
+        "type": "Range",
+        "val": "???"
+      }
+    ],
     "source": "HORUS",
     "license": "PEGASUS",
     "license_level": 2,
@@ -1701,7 +2116,8 @@
         "detail": "Roll a new set of 3d20 to set the Mimic Gun's values."
       }
     ],
-    "description": "This is not a gun."
+    "description": "This is not a gun.",
+    "license_id": "mf_pegasus"
   },
   {
     "id": "mw_autogun",
@@ -1710,14 +2126,18 @@
     "type": "Cannon",
     "no_attack": true,
     "no_synergies": true,
-    "damage": [{
-      "type": "Kinetic",
-      "val": 3
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 15
-    }],
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": 3
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
     "source": "HORUS",
     "license": "PEGASUS",
     "license_level": 3,
@@ -1730,7 +2150,8 @@
     ],
     "effect": "This weapon can’t make normal attacks. Instead, you can attack with it as a free action at the end of your turn. It doesn’t benefit from or trigger your talents.",
     "description": "As the name implies, autoguns are automated weapons. Similar to point-defense systems, autoguns are chambered to provide effective fire against armored targets. Typically mounted on a stabilized, secondary arm, a reliably tuned autogun can be trusted to track and eliminate designated enemy units while a pilot concentrates on more specialized weapons or processes. Cheap, with malleable codebases, autoguns are common among active, armed HORUS cells.",
-    "sp": 1
+    "sp": 1,
+    "license_id": "mf_pegasus"
   },
   {
     "id": "mw_siege_cannon",
@@ -1740,21 +2161,28 @@
     "source": "HA",
     "license": "BARBAROSSA",
     "license_level": 3,
-    "profiles": [{
+    "profiles": [
+      {
         "name": "Siege Mode",
-        "range": [{
-          "type": "Range",
-          "val": 30
-        }, {
-          "type": "Blast",
-          "val": 2
-        }],
-        "damage": [{
-          "type": "Explosive",
-          "val": "3d6"
-        }],
-    "on_attack": "Choose to fire in either siege mode or direct fire mode.",
-    "tags": [{
+        "range": [
+          {
+            "type": "Range",
+            "val": 30
+          },
+          {
+            "type": "Blast",
+            "val": 2
+          }
+        ],
+        "damage": [
+          {
+            "type": "Explosive",
+            "val": "3d6"
+          }
+        ],
+        "on_attack": "Choose to fire in either siege mode or direct fire mode.",
+        "tags": [
+          {
             "id": "tg_arcing"
           },
           {
@@ -1771,16 +2199,21 @@
       },
       {
         "name": "Direct Fire Mode",
-        "range": [{
-          "type": "Range",
-          "val": 20
-        }],
-        "damage": [{
-          "type": "Explosive",
-          "val": "3d6"
-        }],
-    "on_attack": "Choose to fire in either siege mode or direct fire mode.",
-    "tags": [{
+        "range": [
+          {
+            "type": "Range",
+            "val": 20
+          }
+        ],
+        "damage": [
+          {
+            "type": "Explosive",
+            "val": "3d6"
+          }
+        ],
+        "on_attack": "Choose to fire in either siege mode or direct fire mode.",
+        "tags": [
+          {
             "id": "tg_knockback",
             "val": 2
           },
@@ -1791,14 +2224,16 @@
         ]
       }
     ],
-    "description": "The siege cannon is the Armory’s quintessential artillery piece: a howitzer cannon fed by an automated loading system. Typically mounted on long-range mechs deployed in artillery or squad-support roles, siege cannons are capable of both indirect and direct fire as the situation demands with variable ammunition options."
+    "description": "The siege cannon is the Armory’s quintessential artillery piece: a howitzer cannon fed by an automated loading system. Typically mounted on long-range mechs deployed in artillery or squad-support roles, siege cannons are capable of both indirect and direct fire as the situation demands with variable ammunition options.",
+    "license_id": "mf_barbarossa"
   },
   {
     "id": "mw_krakatoa_thermobaric_flamethrower",
     "name": "KRAKATOA THERMOBARIC FLAMETHROWER",
     "mount": "Heavy",
     "type": "CQB",
-    "damage": [{
+    "damage": [
+      {
         "type": "Energy",
         "val": 1
       },
@@ -1807,21 +2242,25 @@
         "val": 4
       }
     ],
-    "range": [{
-      "type": "Cone",
-      "val": 5
-    }],
+    "range": [
+      {
+        "type": "Cone",
+        "val": 5
+      }
+    ],
     "source": "HA",
     "license": "GENGHIS",
     "license_level": 1,
-    "description": "Between the thick arboreal environment of Hercynia, the swarm tactics of the Egregorians, and the ineffectual performance of slug ammunition, the need for wide-effect weapons was apparent. GMS quick developed the Krakatoa – a thermobaric flamethrower – and disseminated it to affiliates. The Krakatoa was quickly adopted by Union’s Marine Expeditionary Forces, seeing heavy use in the depths of the Hercynian continental jungles thanks to its stability, reliability, and stopping power.<br>Later reworked and adopted by the Armory following the resolution of the Hercynian Crisis, the Krakatoa has become a popular tool for the creation of area-of-denial firebreaks."
+    "description": "Between the thick arboreal environment of Hercynia, the swarm tactics of the Egregorians, and the ineffectual performance of slug ammunition, the need for wide-effect weapons was apparent. GMS quick developed the Krakatoa – a thermobaric flamethrower – and disseminated it to affiliates. The Krakatoa was quickly adopted by Union’s Marine Expeditionary Forces, seeing heavy use in the depths of the Hercynian continental jungles thanks to its stability, reliability, and stopping power.<br>Later reworked and adopted by the Armory following the resolution of the Hercynian Crisis, the Krakatoa has become a popular tool for the creation of area-of-denial firebreaks.",
+    "license_id": "mf_genghis"
   },
   {
     "id": "mw_plasma_thrower",
     "name": "PLASMA THROWER",
     "mount": "Superheavy",
     "type": "CQB",
-    "damage": [{
+    "damage": [
+      {
         "type": "Energy",
         "val": "1d6+2"
       },
@@ -1830,7 +2269,8 @@
         "val": 6
       }
     ],
-    "range": [{
+    "range": [
+      {
         "type": "Cone",
         "val": 7
       },
@@ -1839,31 +2279,39 @@
         "val": 10
       }
     ],
-    "tags": [{
-      "id": "tg_heat_self",
-      "val": 4
-    }],
+    "tags": [
+      {
+        "id": "tg_heat_self",
+        "val": 4
+      }
+    ],
     "source": "HA",
     "license": "GENGHIS",
     "license_level": 3,
     "effect": "Can be fired as Cone 7 <i>or</i> Line 10",
     "on_attack": "White-hot flames continue to burn in 3 free spaces of your choice within the affected area, lasting for the rest of the scene. When characters start their turn in one of these spaces or enter one for the first time in a round, they take 1d6 energy damage.",
-    "description": "The plasma thrower emerged too late in the Hercynian Crisis to see widespread use in the field. The scarce data gathered from the MEF squadrons that used it suggest that plasma throwers would have had a tremendous impact on the outcomes of several major battles that occurred during the bloodiest phase of the Crisis."
+    "description": "The plasma thrower emerged too late in the Hercynian Crisis to see widespread use in the field. The scarce data gathered from the MEF squadrons that used it suggest that plasma throwers would have had a tremendous impact on the outcomes of several major battles that occurred during the bloodiest phase of the Crisis.",
+    "license_id": "mf_genghis"
   },
   {
     "id": "mw_stub_cannon",
     "name": "STUB CANNON",
     "mount": "Auxiliary",
     "type": "Cannon",
-    "damage": [{
-      "type": "Explosive",
-      "val": 3
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 5
-    }],
-    "tags": [{
+    "damage": [
+      {
+        "type": "Explosive",
+        "val": 3
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_limited",
         "val": 6
       },
@@ -1875,7 +2323,8 @@
     "source": "HA",
     "license": "ISKANDER",
     "license_level": 1,
-    "description": "The stub cannon is a supercompact rotary cannon – short-range, but suitable for integration into hardpoints and manipulators."
+    "description": "The stub cannon is a supercompact rotary cannon – short-range, but suitable for integration into hardpoints and manipulators.",
+    "license_id": "mf_iskander"
   },
   {
     "id": "mw_gravity_gun",
@@ -1885,7 +2334,8 @@
     "mount": "Heavy",
     "type": "Rifle",
     "damage": [],
-    "range": [{
+    "range": [
+      {
         "type": "Range",
         "val": 8
       },
@@ -1898,18 +2348,22 @@
     "license": "ISKANDER",
     "license_level": 2,
     "on_attack": "Characters within the affected area must succeed on a Hull save or take 1d6 energy damage and be pulled as close to the center of the blast possible. This weapon cannot be modified or benefit from core bonuses.",
-    "description": "“The complex negotiations of gravity and time, shattered in an instant by a machine that can pluck waves like a player strums the strings of a guitar.<br>We’ve weaponized the force that holds all things in its embrace. What could go wrong?”"
+    "description": "“The complex negotiations of gravity and time, shattered in an instant by a machine that can pluck waves like a player strums the strings of a guitar.<br>We’ve weaponized the force that holds all things in its embrace. What could go wrong?”",
+    "license_id": "mf_iskander"
   },
   {
     "id": "mw_displacer",
     "name": "DISPLACER",
     "mount": "Main",
     "type": "Rifle",
-    "damage": [{
-      "type": "Energy",
-      "val": 10
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Energy",
+        "val": 10
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 10
       },
@@ -1918,7 +2372,8 @@
         "val": 1
       }
     ],
-    "tags": [{
+    "tags": [
+      {
         "id": "tg_ap"
       },
       {
@@ -1935,37 +2390,46 @@
     "source": "HA",
     "license": "NAPOLEON",
     "license_level": 3,
-    "description": "The Displacer is the result of ongoing blinkspace exposure tests and refinement of standard interstellar travel methods. In terms of appearance, the Displacer could be mistaken for a conventional energy rifle, but it requires a massive secondary, dorsal-mounted reactor: when fired, the Displacer identifies a bubble of local space (size and location determined on an ad hoc basis by the user) and snaps it into blinkspace. The destination of the bubble is unknown, but the effect is dramatic: anything inside simply ceases to exist in this dimension, transported somewhere in the void of blinkspace. The Displacer makes no sound when fired, but the sudden and necessary venting of its power supply is tremendous; similarly, the heatwave of its backblast vent is deadly to any unshielded personnel exposed to it."
+    "description": "The Displacer is the result of ongoing blinkspace exposure tests and refinement of standard interstellar travel methods. In terms of appearance, the Displacer could be mistaken for a conventional energy rifle, but it requires a massive secondary, dorsal-mounted reactor: when fired, the Displacer identifies a bubble of local space (size and location determined on an ad hoc basis by the user) and snaps it into blinkspace. The destination of the bubble is unknown, but the effect is dramatic: anything inside simply ceases to exist in this dimension, transported somewhere in the void of blinkspace. The Displacer makes no sound when fired, but the sudden and necessary venting of its power supply is tremendous; similarly, the heatwave of its backblast vent is deadly to any unshielded personnel exposed to it.",
+    "license_id": "mf_napoleon"
   },
   {
     "id": "mw_shatterhead_colony_missiles",
     "name": "SHATTERHEAD COLONY MISSILES",
     "mount": "Main",
     "type": "Launcher",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d3+1"
-    }],
-    "range": [{
-      "type": "Range",
-      "val": 15
-    }],
-    "tags": [{
-      "id": "tg_arcing"
-    }],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d3+1"
+      }
+    ],
+    "range": [
+      {
+        "type": "Range",
+        "val": 15
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_arcing"
+      }
+    ],
     "source": "HA",
     "license": "SALADIN",
     "license_level": 1,
     "effect": "The final attack roll for this weapon can never be affected by difficulty.",
     "description": "Developed following costly urban and naval boarding engagements in the Interest War, Shatterhead Colony Missiles are now a standard part of the arsenal fielded by Armory interdiction teams. When they reach an optimal distance, Shatterheads break open in a burst of high-catalyst fuel to reveal a cluster of small thermobaric pellets that spread out and ignite, choking the affected area with flame. The effect overloads energy shielding and saturates cover, though only a small percent of the projectiles actually reach their target.",
-    "sp": 1
+    "sp": 1,
+    "license_id": "mf_saladin"
   },
   {
     "id": "mw_sol_pattern_laser_rifle",
     "name": "SOL-PATTERN LASER RIFLE",
     "mount": "Main",
     "type": "Rifle",
-    "damage": [{
+    "damage": [
+      {
         "type": "Energy",
         "val": "1d6"
       },
@@ -1974,25 +2438,31 @@
         "val": 1
       }
     ],
-    "range": [{
-      "type": "Range",
-      "val": 8
-    }],
-    "tags": [{
-      "id": "tg_heat_self",
-      "val": 1
-    }],
+    "range": [
+      {
+        "type": "Range",
+        "val": 8
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_heat_self",
+        "val": 1
+      }
+    ],
     "source": "HA",
     "license": "SHERMAN",
     "license_level": 1,
-    "description": "Laser rifles contain a series of apertures and lenses that amplify and focus light into tight beams, sometimes visible, that heat the zone of impact for long enough to turn it into plasma. The SOL-Pattern Laser Rifle consistently outputs 3.5 petawatts, pulsed, but can also project a steady beam at lower power levels. The SOL is entirely self-contained but can be patched into a mech’s reactor core for emergency recharge.<br>Although some laser rifles double as communications and data-transfer devices, the SOL is strictly suitable for combat applications."
+    "description": "Laser rifles contain a series of apertures and lenses that amplify and focus light into tight beams, sometimes visible, that heat the zone of impact for long enough to turn it into plasma. The SOL-Pattern Laser Rifle consistently outputs 3.5 petawatts, pulsed, but can also project a steady beam at lower power levels. The SOL is entirely self-contained but can be patched into a mech’s reactor core for emergency recharge.<br>Although some laser rifles double as communications and data-transfer devices, the SOL is strictly suitable for combat applications.",
+    "license_id": "mf_sherman"
   },
   {
     "id": "mw_andromeda_pattern_heavy_laser_rifle",
     "name": "ANDROMEDA-PATTERN HEAVY LASER RIFLE",
     "mount": "Heavy",
     "type": "Cannon",
-    "damage": [{
+    "damage": [
+      {
         "type": "Energy",
         "val": "2d6"
       },
@@ -2001,25 +2471,31 @@
         "val": 3
       }
     ],
-    "range": [{
-      "type": "Range",
-      "val": 12
-    }],
-    "tags": [{
-      "id": "tg_heat_self",
-      "val": 3
-    }],
+    "range": [
+      {
+        "type": "Range",
+        "val": 12
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_heat_self",
+        "val": 3
+      }
+    ],
     "source": "HA",
     "license": "SHERMAN",
     "license_level": 2,
-    "description": "The Harrison Armory ANDROMEDA-Pattern Heavy Laser Rifle scales up the SOL by half, adding a second projector that can fire independently, synchronized, or in alternating patterns and wavelengths with the primary projector. The effect overwhelms most shields, but the power draw necessary makes this weapon impractical on platforms without the necessary heat reduction and dispersal to manage the incredible cost."
+    "description": "The Harrison Armory ANDROMEDA-Pattern Heavy Laser Rifle scales up the SOL by half, adding a second projector that can fire independently, synchronized, or in alternating patterns and wavelengths with the primary projector. The effect overwhelms most shields, but the power draw necessary makes this weapon impractical on platforms without the necessary heat reduction and dispersal to manage the incredible cost.",
+    "license_id": "mf_sherman"
   },
   {
     "id": "mw_tachyon_lance",
     "name": "TACHYON LANCE",
     "mount": "Superheavy",
     "type": "Cannon",
-    "damage": [{
+    "damage": [
+      {
         "type": "Energy",
         "val": "2d6"
       },
@@ -2028,11 +2504,14 @@
         "val": 8
       }
     ],
-    "range": [{
-      "type": "Range",
-      "val": 20
-    }],
-    "tags": [{
+    "range": [
+      {
+        "type": "Range",
+        "val": 20
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_ordnance"
       },
       {
@@ -2044,18 +2523,22 @@
     "license": "SHERMAN",
     "license_level": 3,
     "on_attack": "If you’re in the Danger Zone, create a cone 3 backblast of burning plasma in the opposite direction to the attack. Characters within the affected area must succeed on an Engineering save or take 4 burn and 2 heat. Until the start of your next turn, the affected area provides soft cover.",
-    "description": "Tachyon lances are the weaponized results of joint IPS-N and Harrison Armory experiments into faster-than-light travel. Rendered obsolete by subsequent developments in blinkspace travel (and the difficulty of ensuring corporeal passenger survival), the Armory’s tachyon accelerators were mothballed until Think Tank engineers realized their potential application as weapons. Tachyon lances project tachyon particles – essentially subatomic localized objects – faster than light toward their targets. These particles are impossible to perceive optically, and because they travel faster than light, can’t be seen or evaded. Although the particles are tiny, they travel with colossal speed and energy. The damage a tachyon lance deals to its target – should it hit – is unparalleled."
+    "description": "Tachyon lances are the weaponized results of joint IPS-N and Harrison Armory experiments into faster-than-light travel. Rendered obsolete by subsequent developments in blinkspace travel (and the difficulty of ensuring corporeal passenger survival), the Armory’s tachyon accelerators were mothballed until Think Tank engineers realized their potential application as weapons. Tachyon lances project tachyon particles – essentially subatomic localized objects – faster than light toward their targets. These particles are impossible to perceive optically, and because they travel faster than light, can’t be seen or evaded. Although the particles are tiny, they travel with colossal speed and energy. The damage a tachyon lance deals to its target – should it hit – is unparalleled.",
+    "license_id": "mf_sherman"
   },
   {
     "id": "mw_annihilator",
     "name": "ANNIHILATOR",
     "mount": "Main",
     "type": "CQB",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d3+2"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d3+2"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 5
       },
@@ -2064,7 +2547,8 @@
         "val": 3
       }
     ],
-    "tags": [{
+    "tags": [
+      {
         "id": "tg_ap"
       },
       {
@@ -2076,14 +2560,16 @@
     "license": "TOKUGAWA",
     "license_level": 1,
     "on_hit": "Make a secondary attack against all characters within burst 1 of the target. These attacks can’t deal bonus damage, and don’t trigger the Annihilator’s heat cost or secondary attacks.",
-    "description": "Harrison Armory is known to employ somewhat unconventional development methods: tactical solutions are theorized and designed in the field as often as they are in the lab, with the former often outperforming the latter. The Annihilator’s name comes from pilots’ slang for a jury-rigged weapon first improvised in the Bradbury Rebellion, when desperate resistance pilots found a way to shunt the incredible waste heat from their reactors into a directed blast."
+    "description": "Harrison Armory is known to employ somewhat unconventional development methods: tactical solutions are theorized and designed in the field as often as they are in the lab, with the former often outperforming the latter. The Annihilator’s name comes from pilots’ slang for a jury-rigged weapon first improvised in the Bradbury Rebellion, when desperate resistance pilots found a way to shunt the incredible waste heat from their reactors into a directed blast.",
+    "license_id": "mf_tokugawa"
   },
   {
     "id": "mw_torch",
     "name": "TORCH",
     "mount": "Main",
     "type": "Melee",
-    "damage": [{
+    "damage": [
+      {
         "type": "Energy",
         "val": "1d6"
       },
@@ -2092,11 +2578,14 @@
         "val": 3
       }
     ],
-    "range": [{
-      "type": "Threat",
-      "val": 1
-    }],
-    "tags": [{
+    "range": [
+      {
+        "type": "Threat",
+        "val": 1
+      }
+    ],
+    "tags": [
+      {
         "id": "tg_overkill"
       },
       {
@@ -2107,18 +2596,22 @@
     "source": "HA",
     "license": "TOKUGAWA",
     "license_level": 2,
-    "description": "The Torch is a potent weapon: a heavy  crescent-bladed plasma cutter, powered straight from a chassis’ reactor. Torches generally project as axes, though their blades can be changed to a range of other shapes. A common weapon in CQB theaters, the torch has lately become a status symbol among officers, carried by many alongside a smaller auxiliary weapon."
+    "description": "The Torch is a potent weapon: a heavy  crescent-bladed plasma cutter, powered straight from a chassis’ reactor. Torches generally project as axes, though their blades can be changed to a range of other shapes. A common weapon in CQB theaters, the torch has lately become a status symbol among officers, carried by many alongside a smaller auxiliary weapon.",
+    "license_id": "mf_tokugawa"
   },
   {
     "id": "mw_fuel_rod_gun",
     "name": "Fuel Rod Gun",
     "mount": "Main",
     "type": "CQB",
-    "damage": [{
-      "type": "Energy",
-      "val": "1d3+2"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "1d3+2"
+      }
+    ],
+    "range": [
+      {
         "type": "Range",
         "val": 3
       },
@@ -2127,7 +2620,8 @@
         "val": 3
       }
     ],
-    "tags": [{
+    "tags": [
+      {
         "id": "tg_limited",
         "val": 3
       },
@@ -2142,18 +2636,22 @@
     "talent_id": "t_nuclear_cavalier",
     "talent_rank": 3,
     "on_attack": "Clear 4 heat.",
-    "description": "Gained from the \"Nuclear Cavalier\" Rank 3 Talent"
+    "description": "Gained from the \"Nuclear Cavalier\" Rank 3 Talent",
+    "license_id": ""
   },
   {
     "id": "mw_prototype_1",
     "name": "Prototype Weapon I",
     "mount": "Main",
     "type": "Special",
-    "damage": [{
-      "type": "Variable",
-      "val": "1d6+2"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Variable",
+        "val": "1d6+2"
+      }
+    ],
+    "range": [
+      {
         "type": "Threat",
         "val": 1
       },
@@ -2162,7 +2660,8 @@
         "val": 10
       }
     ],
-    "tags": [{
+    "tags": [
+      {
         "id": "tg_limited",
         "val": "1d6+2"
       },
@@ -2183,18 +2682,22 @@
     "talent_id": "t_engineer",
     "talent_rank": 1,
     "effect": "This weapon is an experimental prototype, customized according to your specific requirements.<br>When you install it, or during a Full Repair, you may choose a new weapon type, damage type, and either Threat 1 (melee) or Range 10 (all other types). Additionally, each time you perform a Full Repair, reroll 1d6+2 to determine this weapon’s Limited uses.",
-    "description": "Gained from the <i>\"Engineer\" Rank I</i> Talent"
+    "description": "Gained from the <i>\"Engineer\" Rank I</i> Talent",
+    "license_id": ""
   },
   {
     "id": "mw_prototype_2",
     "name": "Prototype Weapon II",
     "mount": "Main",
     "type": "Special",
-    "damage": [{
-      "type": "Variable",
-      "val": "1d6+2"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Variable",
+        "val": "1d6+2"
+      }
+    ],
+    "range": [
+      {
         "type": "Threat",
         "val": 1
       },
@@ -2203,7 +2706,8 @@
         "val": 10
       }
     ],
-    "tags": [{
+    "tags": [
+      {
         "id": "tg_limited",
         "val": "1d6+2"
       },
@@ -2224,18 +2728,22 @@
     "talent_id": "t_engineer",
     "talent_rank": 2,
     "effect": "This weapon is an experimental prototype, customized according to your specific requirements.<br>When you install it, or during a Full Repair, you may choose a new weapon type, damage type, and either Threat 1 (melee) or Range 10 (all other types). Additionally, each time you perform a Full Repair, reroll 1d6+2 to determine this weapon’s Limited uses and choose two:<ul><li><b>Tweaked Optics:</b> Your prototype weapon always gains +1 Accuracy on attacks.</li><li><b>Tweaked Computer:</b> Your prototype weapon is Smart.</li><li><b>Stripped reactor shielding:</b> Each time you attack with your prototype weapon, you may choose – at the cost of 2 Heat – to attack with one of the following options, depending on its weapon type:<ul><li><b>Ranged weapon:</b> Cone 3, Line 5, or [Blast 1, Range 10].</li><li><b>Melee weapon:</b> Burst 1.</li></li></ul></ul>",
-    "description": "Gained from the <i>\"Engineer\" Rank II</i> Talent"
+    "description": "Gained from the <i>\"Engineer\" Rank II</i> Talent",
+    "license_id": ""
   },
   {
     "id": "mw_prototype_3",
     "name": "Prototype Weapon III",
     "mount": "Main",
     "type": "Special",
-    "damage": [{
-      "type": "Variable",
-      "val": "1d6+4"
-    }],
-    "range": [{
+    "damage": [
+      {
+        "type": "Variable",
+        "val": "1d6+4"
+      }
+    ],
+    "range": [
+      {
         "type": "Threat",
         "val": 1
       },
@@ -2244,7 +2752,8 @@
         "val": 10
       }
     ],
-    "tags": [{
+    "tags": [
+      {
         "id": "tg_limited",
         "val": "2d6"
       },
@@ -2265,7 +2774,8 @@
     "talent_id": "t_engineer",
     "talent_rank": 3,
     "effect": "This weapon is an experimental prototype, customized according to your specific requirements.<br>When you install it, or during a Full Repair, you may choose a new weapon type, damage type, and either Threat 1 (melee) or Range 10 (all other types). Additionally, each time you perform a Full Repair, reroll 2d6 to determine this weapon’s Limited uses and choose two:<ul><li><b>Tweaked Optics:</b> Your prototype weapon always gains +1 Accuracy on attacks.</li><li><b>Tweaked Computer:</b> Your prototype weapon is Smart.</li><li><b>Stripped reactor shielding:</b> Each time you attack with your prototype weapon, you may choose – at the cost of 2 Heat – to attack with one of the following options, depending on its weapon type:<ul><li><b>Ranged weapon:</b> Cone 3, Line 5, or [Blast 1, Range 10].</li><li><b>Melee weapon:</b> Burst 1.</li></li></ul></ul>",
-    "description": "Gained from the <i>\"Engineer\" Rank III</i> Talent"
+    "description": "Gained from the <i>\"Engineer\" Rank III</i> Talent",
+    "license_id": ""
   },
   {
     "id": "mw_lancaster_integrated",
@@ -2273,18 +2783,22 @@
     "mount": "Main",
     "type": "Launcher",
     "damage": [],
-    "range": [{
-      "type": "Range",
-      "val": 8
-    }],
-    "effect": "This weapon can’t make normal attacks. Instead, choose an allied mech within Range and line of sight and make a ranged attack against Evasion 8. On a hit, either you or your target may spend 1 Repair to restore half your target’s HP."
+    "range": [
+      {
+        "type": "Range",
+        "val": 8
+      }
+    ],
+    "effect": "This weapon can’t make normal attacks. Instead, choose an allied mech within Range and line of sight and make a ranged attack against Evasion 8. On a hit, either you or your target may spend 1 Repair to restore half your target’s HP.",
+    "license_id": ""
   },
   {
     "id": "mw_raleigh_integrated",
     "name": "M35 Mjolnir",
     "mount": "Main",
     "type": "CQB",
-    "range": [{
+    "range": [
+      {
         "type": "Range",
         "val": 5
       },
@@ -2293,11 +2807,14 @@
         "val": 3
       }
     ],
-    "damage": [{
-      "type": "Kinetic",
-      "val": 4
-    }],
-    "effect": "1/round, when you reload any weapon, this weapon can be fired as a free action."
+    "damage": [
+      {
+        "type": "Kinetic",
+        "val": 4
+      }
+    ],
+    "effect": "1/round, when you reload any weapon, this weapon can be fired as a free action.",
+    "license_id": ""
   },
   {
     "id": "mw_barbarossa_integrated",
@@ -2314,22 +2831,28 @@
         "detail": "If the value of the Apocalypse Die is 1–3, you can attack on your turn with the Apocalypse Rail as a full action, but can’t move or take any other actions on the same turn.<br>After an attack with the Apocalypse Rail, the Apocalypse Die resets to 4."
       }
     ],
-    "profiles": [{
+    "profiles": [
+      {
         "name": "Charge Rail: 4",
-        "damage": [{
-          "override": true,
-          "val": "N/A"
-        }],
-        "range": [{
-          "override": true,
-          "type": "Range",
-          "val": "N/A"
-        }],
+        "damage": [
+          {
+            "override": true,
+            "val": "N/A"
+          }
+        ],
+        "range": [
+          {
+            "override": true,
+            "type": "Range",
+            "val": "N/A"
+          }
+        ],
         "effect": "Cannot Be Fired"
       },
       {
         "name": "Charge Rail: 3",
-        "range": [{
+        "range": [
+          {
             "type": "Range",
             "val": 20
           },
@@ -2338,15 +2861,18 @@
             "val": 2
           }
         ],
-        "damage": [{
-          "type": "Explosive",
-          "val": "2d6"
-        }],
+        "damage": [
+          {
+            "type": "Explosive",
+            "val": "2d6"
+          }
+        ],
         "effect": "Objects within the affected area automatically take 20 AP explosive damage. After the attack, the blast cloud lingers, providing soft cover to characters within the affected area until the end of your next turn."
       },
       {
         "name": "Charge Rail: 2",
-        "range": [{
+        "range": [
+          {
             "type": "Range",
             "val": 25
           },
@@ -2355,15 +2881,18 @@
             "val": 2
           }
         ],
-        "damage": [{
-          "type": "Explosive",
-          "val": "3d6"
-        }],
+        "damage": [
+          {
+            "type": "Explosive",
+            "val": "3d6"
+          }
+        ],
         "effect": "Objects and terrain in the area automatically take 40 AP explosive damage, and on hit characters become Shredded and Impaired until the end of their next turn. The blast cloud is a burning storm: until the end of your next turn, characters within the affected area receive soft cover, and characters that start their turn within the area or move there for the first time in a round take 4 burn."
       },
       {
         "name": "Charge Rail: 1",
-        "range": [{
+        "range": [
+          {
             "type": "Range",
             "val": 30
           },
@@ -2372,13 +2901,16 @@
             "val": 2
           }
         ],
-        "damage": [{
-          "type": "Explosive",
-          "val": "4d6"
-        }],
+        "damage": [
+          {
+            "type": "Explosive",
+            "val": "4d6"
+          }
+        ],
         "effect": "Objects and terrain in the area automatically take 100 AP explosive damage, and characters become Shredded and Stunned until the end of their next turn on hit. The ground in the affected area is vaporized on impact: for the rest of the scene, it is difficult terrain, characters within the affected area receive soft cover, and characters that start their turn with the area or move there for the first time in a round take 4 burn."
       }
-    ]
+    ],
+    "license_id": ""
   },
   {
     "id": "mw_sherman_integrated",
@@ -2388,56 +2920,74 @@
     "profiles": [
       {
         "name": "1 Charge",
-        "range": [{
+        "range": [
+          {
             "type": "Line",
             "val": 4
           }
         ],
-        "damage": [{
-          "type": "Energy",
-          "val": "1d6"
-        }],
+        "damage": [
+          {
+            "type": "Energy",
+            "val": "1d6"
+          }
+        ],
         "effect": "This weapon’s profile is determined by the number of Charges it carries. It begins with 1 Charge, dealing 1d6 energy with line 4. Each time you Stabilize, you gain an additional 1 Charge, up to a maximum of 4. The ZF4 gains an additional +4 range and +1d6 energy damage for each charge, and resets to 1 Charge after each attack. Charges persist between scenes, but are lost during a full repair."
-      }, {
+      },
+      {
         "name": "2 Charges",
-        "range": [{
+        "range": [
+          {
             "type": "Line",
             "val": 8
           }
         ],
-        "damage": [{
-          "type": "Energy",
-          "val": "2d6"
-        }],
+        "damage": [
+          {
+            "type": "Energy",
+            "val": "2d6"
+          }
+        ],
         "effect": "This weapon’s profile is determined by the number of Charges it carries. It begins with 1 Charge, dealing 1d6 energy with line 4. Each time you Stabilize, you gain an additional 1 Charge, up to a maximum of 4. The ZF4 gains an additional +4 range and +1d6 energy damage for each charge, and resets to 1 Charge after each attack. Charges persist between scenes, but are lost during a full repair."
-      }, {
+      },
+      {
         "name": "3 Charges",
-        "range": [{
+        "range": [
+          {
             "type": "Line",
             "val": 12
           }
         ],
-        "damage": [{
-          "type": "Energy",
-          "val": "3d6"
-        }],
+        "damage": [
+          {
+            "type": "Energy",
+            "val": "3d6"
+          }
+        ],
         "effect": "This weapon’s profile is determined by the number of Charges it carries. It begins with 1 Charge, dealing 1d6 energy with line 4. Each time you Stabilize, you gain an additional 1 Charge, up to a maximum of 4. The ZF4 gains an additional +4 range and +1d6 energy damage for each charge, and resets to 1 Charge after each attack. Charges persist between scenes, but are lost during a full repair."
-      }, {
+      },
+      {
         "name": "4 Charges",
-        "range": [{
+        "range": [
+          {
             "type": "Line",
             "val": 16
           }
         ],
-        "damage": [{
-          "type": "Energy",
-          "val": "4d6"
-        }],
+        "damage": [
+          {
+            "type": "Energy",
+            "val": "4d6"
+          }
+        ],
         "effect": "This weapon’s profile is determined by the number of Charges it carries. It begins with 1 Charge, dealing 1d6 energy with line 4. Each time you Stabilize, you gain an additional 1 Charge, up to a maximum of 4. The ZF4 gains an additional +4 range and +1d6 energy damage for each charge, and resets to 1 Charge after each attack. Charges persist between scenes, but are lost during a full repair."
       }
     ],
-    "tags": [{
-      "id": "tg_ordnance"
-    }]
+    "tags": [
+      {
+        "id": "tg_ordnance"
+      }
+    ],
+    "license_id": ""
   }
 ]


### PR DESCRIPTION
# Description
Due to the growing popularity of homebrew LCPs, homebrew users and authors are inevitably run into license name collisions.  This PR aims to introduce a new data field, `license_id`, to ILicensedItemData, which will refer back to the ID of the frame for a given license.  This will enable homebrew creators to keep their content from overlapping with other creators, since LCP IDs allow for more uniqueness than just names.  

This pattern will also continue to enable homebrew items made for an existing license (e.g. a new system for the Blackbeard), whereas a pattern of matching items based upon "Brew" would prevent such additions (e.g. if Blackbeard's brew is "Core", its license would only include LicensedItems from the same brew).

To implement this in COMP/CON proper, this `license_id` will become the primary matching ID for licenses; if the field does not exist, COMP/CON will fall back to the v2.3.7a logic of matching License Name to Frame Name (and potentially License Source to Frame Source; see https://github.com/massif-press/compcon/pull/1982).

## Issue Number
Will help enable a robust solution for https://github.com/massif-press/compcon/issues/1981