### PR TITLE
fix(data): match heatfall & rules overcharge format

### DIFF
--- a/lib/core_bonuses.json
+++ b/lib/core_bonuses.json
@@ -293,7 +293,7 @@
     "description": "The Heatfall Coolant System comes packaged with a stabilized reactor core; paired together, this combo is guaranteed to keep a mech cool in nearly any environment.",
     "bonuses": [{
       "id": "overcharge",
-      "val": ["+1", "+1d3", "+1d6", "+1d6"]
+      "val": ["1", "1d3", "1d6", "1d6"]
     }]
   },
   {


### PR DESCRIPTION
# Description
This PR adjusts the Overcharge track granted by Heatfall Coolant Systems to match the format found in the `rules.json` (i.e. remove leading `+` from each entry).

## Issue Number
Closes [compcon #2030](https://github.com/massif-press/compcon/issues/2030)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)