### PR TITLE
fix(data):type-I flight system synergy made 'move'

### DIFF
--- a/lib/systems.json
+++ b/lib/systems.json
@@ -395,9 +395,9 @@
     "synergies": [
       {
         "locations": [
-          "boost"
+          "move"
         ],
-        "detail": "You can fly when you Boost; however, you must end the movement on the ground or another solid surface, or else immediately begin falling."
+        "detail": "You may choose to count any and all of your movement as flying; however, you take Size +1 Heat at the end of any of your turns in which you fly this way."
       }
     ],
     "license_id": ""


### PR DESCRIPTION
# Description
This PR fixes the Type-I Flight System's synergy to use the system's own detail instead of the Rapid Burst Jump Jet System's synergy. It also changes the synergy to "move" instead of "boost".

## Issue Number
None yet.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)