### PR TITLE
fix(data): Tactician 2 ranged synergy fix

### DIFF
--- a/lib/talents.json
+++ b/lib/talents.json
@@ -1447,12 +1447,16 @@
               "weapon"
             ],
             "weapon_types": [
-              "Ranged"
+              "Rifle",
+              "Cannon",
+              "Launcher",
+              "CQB",
+              "Nexus"
             ],
             "weapon_sizes": [
               "any"
             ],
-            "detail": "1/round, gain +1 Accuracy on any ranged attack made while you are at a higher elevation than your target.t"
+            "detail": "1/round, gain +1 Accuracy on any ranged attack made while you are at a higher elevation than your target."
           }
         ]
       },


### PR DESCRIPTION
# Description
This PR fixes Tactician 2's ranged attack synergy to cover all non-melee weapon types.

## Issue Number
Closes #179

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)