### PR TITLE
feat(data): decap Talents, CBs, Counters

### DIFF
--- a/lib/core_bonuses.json
+++ b/lib/core_bonuses.json
@@ -8,7 +8,7 @@
   },
   {
     "id": "cb_auto_stabilizing_hardpoints",
-    "name": "AUTO-STABILIZING HARDPOINTS",
+    "name": "Auto-Stabilizing Hardpoints",
     "source": "GMS",
     "effect": "Choose one mount. Weapons attached to this mount gain +1 Accuracy.",
     "description": "Using the best in shock-absorption and steadytech, you can retain accuracy across longer, sustained periods of fire.",
@@ -16,7 +16,7 @@
   },
   {
     "id": "cb_overpower_caliber",
-    "name": "OVERPOWER CALIBER",
+    "name": "Overpower Caliber",
     "source": "GMS",
     "effect": "Choose one weapon. 1/round, when you hit with an attack, you can cause it to deal +1d6 bonus damage.",
     "description": "Instead of the standardized option, you requisition multiple racks of “hot” ammunition – same-bore slugs, with a higher grade of accelerant.",
@@ -24,21 +24,21 @@
   },
   {
     "id": "cb_improved_armament",
-    "name": "IMPROVED ARMAMENT",
+    "name": "Improved Armament",
     "source": "GMS",
     "effect": "If your mech has fewer than three mounts (excluding integrated mounts), it gains an additional Flexible mount.",
     "description": "By rerouting power and strengthening systems, you can mount additional weapons beyond the factory recommendations."
   },
   {
     "id": "cb_integrated_weapon",
-    "name": "INTEGRATED WEAPON",
+    "name": "Integrated Weapon",
     "source": "GMS",
     "effect": "Your mech gains a new integrated mount with capacity for one Auxiliary weapon. This weapon can be fired 1/round as a free action when you fire any other weapon on your mech. It can’t be modified.",
     "description": "The empty spaces in your mech’s chassis – inside fists, chest plates, anywhere there’s room – are filled with integrated weapons, ready to fire on reflex."
   },
   {
     "id": "cb_mount_retrofitting",
-    "name": "MOUNT RETROFITTING",
+    "name": "Mount Retrofitting",
     "source": "GMS",
     "effect": "Replace one mount with a Main/Aux mount.",
     "description": "By re-fabricating certain components and hardpoints on your chassis for more efficient distribution, you can increase your mech’s firepower.",
@@ -46,21 +46,21 @@
   },
   {
     "id": "cb_universal_compatibility",
-    "name": "UNIVERSAL COMPATIBILITY",
+    "name": "Universal Compatibility",
     "source": "GMS",
     "effect": "Any time you spend CP to activate a Core System, you may also take a free action to restore all HP, cool all Heat, and roll 1d20: on 20, regain 1 CP.",
     "description": "The Everest is everywhere: so are the parts you need for a field repair."
   },
   {
     "id": "cb_briareos_frame",
-    "name": "BRIAREOS FRAME",
+    "name": "Briareos Frame",
     "source": "IPS-N",
     "effect": "As long as your mech has no more than 1 Structure, you gain Resistance to all damage. When it’s reduced to 0 HP and 0 Structure, it is not destroyed: instead, you must make a structure damage check each time it takes damage. While in this state, your mech cannot regain HP until you rest or perform a Full Repair, at which point your mech can be repaired normally.",
     "description": "The Briareos is the newest release in IPS-N’s line of near-fail frame upgrades: templates designed to maximize a mech’s usability before catastrophic failure or the need for a reprint. The Briareos template increases the resilience of inorganic components by supplementing the structure with a superlight frame featuring interwoven layers of IPS-N’s iconic Goliath Weave meshing."
   },
   {
     "id": "cb_fomorian_frame",
-    "name": "FOMORIAN FRAME",
+    "name": "Fomorian Frame",
     "source": "IPS-N",
     "effect": "Increase your mech’s Size by one increment (e.g., from 1/2 to 1, 1 to 2, or 2 to 3) up to a maximum of 3 Size. You can’t be knocked Prone, pulled, or knocked back by smaller characters, regardless of what system or weapon causes the effect.",
     "description": "The Fomorian is an upscaled version of IPS-N’s stock template that has been adapted to meet the needs of long-haul Cosmopolitans looking for enhanced stability and robust impact protection, both micro- and macro-level.",
@@ -71,7 +71,7 @@
   },
   {
     "id": "cb_gyges_frame",
-    "name": "GYGES FRAME",
+    "name": "Gyges Frame",
     "source": "IPS-N",
     "effect": "You gain +1 Accuracy on all Hull checks and saves and +1 Threat with all melee weapons.",
     "description": "A mech built on the Gyges template is designed for combat – enhanced with finely tuned stabilizers and a robust suite of targeting software and hardware.",
@@ -88,7 +88,7 @@
   },
   {
     "id": "cb_reinforced_frame",
-    "name": "REINFORCED FRAME",
+    "name": "Reinforced Frame",
     "source": "IPS-N",
     "effect": "You gain +5 HP.",
     "description": "The addition of redundant shock-absorption systems increases the survivability of pilots in combat, flight, and industrial situations.",
@@ -99,7 +99,7 @@
   },
   {
     "id": "cb_sloped_plating",
-    "name": "SLOPED PLATING",
+    "name": "Sloped Plating",
     "source": "IPS-N",
     "effect": "You gain +1 Armor, up to the maximum (+4).",
     "description": "A common choice among pilots with the right licenses, IPS-N’s integrated-armor fabrication reduces gaps in external coverage by a significant percentage.",
@@ -110,7 +110,7 @@
   },
   {
     "id": "cb_titanomachy_mesh",
-    "name": "TITANOMACHY MESH",
+    "name": "Titanomachy Mesh",
     "source": "IPS-N",
     "effect": "1/round, when you successfully Ram or Grapple a mech, you can Ram or Grapple again as a free action. Additionally, when you knock targets back with melee attacks, you knock them back 1 additional space.",
     "description": "A double overlay of Goliath Weave at key stress points and beefed-up specifications across the board greatly improve the baseline functionality of any mech.",
@@ -121,7 +121,7 @@
   },
   {
     "id": "cb_all_theater_movement_suite",
-    "name": "ALL-THEATER MOVEMENT SUITE",
+    "name": "All-Theater Movement Suite",
     "source": "SSC",
     "effect": "You may choose to count any and all of your movement as flying; however, you take 1 Heat at the end of each of your turns in which you fly this way.",
     "description": "A popular modification, ATMS adds powerful pulse jets that dramatically improve mech mobility in all theaters.",
@@ -132,7 +132,7 @@
   },
   {
     "id": "cb_full_subjectivity_sync",
-    "name": "FULL SUBJECTIVITY SYNC",
+    "name": "Full Subjectivity Sync",
     "source": "SSC",
     "effect": "You gain +2 Evasion.",
     "description": "By creating a stable, two-way ontologic bridge, SSC has removed the need for pilots to rely on physical controls alone to pilot their mech. Using a full subjectivity sync, pilots perceive their mech as their own body and control it via neural impulse; somatosensory feedback is translated to the pilot as well, so caution is advised despite nociception-dampening defaults built-in to the system.",
@@ -143,14 +143,14 @@
   },
   {
     "id": "cb_ghostweave",
-    "name": "GHOSTWEAVE",
+    "name": "Ghostweave",
     "source": "SSC",
     "effect": "During your turn, you are Invisible. If you take no actions on your turn other than your standard move, Hide, and Boost, you remain Invisible until the start of your next turn. You immediately cease to be Invisible when you take a reaction.",
     "description": "An upscaled version of the same systems found in SSC’s Mythimna Panoply, Ghostweave is a proprietary appliqué used to enhance mech camouflage in all environments."
   },
   {
     "id": "cb_integrated_nerveweave",
-    "name": "INTEGRATED NERVEWEAVE",
+    "name": "Integrated Nerveweave",
     "source": "SSC",
     "effect": "You may move an additional 2 spaces when you Boost.",
     "description": "Integrated nerveweave combines several technologies to grant total battlefield alacrity, assuring pilots are never left behind.",
@@ -161,7 +161,7 @@
   },
   {
     "id": "cb_kai_bioplating",
-    "name": "KAI BIOPLATING",
+    "name": "Kai Bioplating",
     "source": "SSC",
     "effect": "You gain +1 Accuracy on all Agility checks and saves; additionally, you climb and swim at normal speed, ignore difficult terrain, and when making a standard move, can jump horizontally up to your full Speed and upwards up to half your Speed  (in any combination).",
     "description": "Adapted from fauna local to SSC’s home system, Kai Bioplating adds a lamellar layer of insulated, anchored, and chitinous plating over key brush-points on a mech. Essentially a cheaper, more feasible alternative to living metal, bioplating allows for faster movement through hard-to-navigate terrain.",
@@ -175,7 +175,7 @@
   },
   {
     "id": "cb_neurolink_targeting",
-    "name": "NEUROLINK TARGETING",
+    "name": "Neurolink Targeting",
     "source": "SSC",
     "effect": "Your ranged weapons gain +3 Range.",
     "description": "To further reduce the information gap between pilot and machine and complement its full subjectivity sync technology, SSC developed neurolinking, a stable, non-invasive, and limited-transfer ontologic bridge. Neurolink targeting is a simple enhancement that helps pilots feel – as opposed to thinking – when engaged in ranged combat, allowing for a more natural expression of pilot ability.",
@@ -187,7 +187,7 @@
   },
   {
     "id": "cb_the_lesson_of_disbelief",
-    "name": "THE LESSON OF DISBELIEF",
+    "name": "The Lesson of Disbelief",
     "source": "HORUS",
     "effect": "You gain +1 accuracy on Systems checks and saves, and +2 E-Defense.",
     "description": "Query the omninet, delve into the archives. Find you the Aeneid, find you the age of Titanomachy. Eat, absorb, mull. Tell me now of the Hecatoncheires, they of the hundred hands. Did they strike the blow against Cronus – Saturno – or did they instead assail the Olympians? Who do you believe? Who stopped the Beast from telling its own story? And why? – “Lesson One”, The Six Lessons of Kilo Nueve.",
@@ -203,7 +203,7 @@
   },
   {
     "id": "cb_the_lesson_of_the_open_door",
-    "name": "THE LESSON OF THE OPEN DOOR",
+    "name": "The Lesson of the Open Door",
     "source": "HORUS",
     "effect": "Your Save Target increases by +2; additionally, 1/round, when a character fails a save against you, they take 2 heat.",
     "description": "There is a body and a deep pit, and both are named Tartarus. Once it held kings and titans and myths. Now, the gates that held it back are flung wide, and Tartarus is free. Here is the terrible question: who opened it, and why? – “Lesson Two”, The Six Lessons of Kilo Nueve.",
@@ -214,7 +214,7 @@
   },
   {
     "id": "cb_the_lesson_of_the_held_image",
-    "name": "THE LESSON OF THE HELD IMAGE",
+    "name": "The Lesson of the Held Image",
     "source": "HORUS",
     "effect": "1/round, as a reaction at the start of any allied character’s turn, you may make a Lock On tech action against any character within line of sight and Sensors.",
     "description": "Close your eyes. Hold the image of your enemy in your mind; imagine it in all light and from every angle. In your mind, it has become a more perfect version. Crush it in your mind and kill the perfect thing. Open your eyes. – “Lesson Three”, The Six Lessons of Kilo Nueve.",
@@ -230,7 +230,7 @@
   },
   {
     "id": "cb_the_lesson_of_thinking_tomorrows_thought",
-    "name": "THE LESSON OF THINKING-TOMORROW’S-THOUGHT",
+    "name": "The Lesson of Thinking-Tomorrow’s-Thought",
     "source": "HORUS",
     "effect": "When you hit with a tech attack, your next melee attack against the same target gains +1 accuracy, and its damage can’t be reduced in any way.",
     "description": "Let me tell you this lesson: the corporeal existence is one that must end in death. The incorporeal existence is one that [must] end in [cascade? do you really think that is true?]. I tell you again, if you can imagine it, it is [done] and you have already struck the killing blow. – “Lesson Four”, The Six Lessons of Kilo Nueve.",
@@ -241,14 +241,14 @@
   },
   {
     "id": "cb_the_lesson_of_transubstantiation",
-    "name": "THE LESSON OF TRANSUBSTANTIATION",
+    "name": "The Lesson of Transubstantiation",
     "source": "HORUS",
     "effect": "Any time you take structure damage, you disappear into a non-space and cease to be a valid target. You reappear in the same space at the start of your next turn. If that space is occupied, you reappear in the nearest available free space (chosen by you).",
     "description": "Through ecstatic repetition, you may see the face of God. Speak until your tongue dries and rattles to dust, and your body becomes nothing. When you are nothing and the wind takes you, you are in all things, never to be destroyed, only divided, until time's end. – “Lesson Five”, The Six Lessons of Kilo Nueve."
   },
   {
     "id": "cb_the_lesson_of_shaping",
-    "name": "THE LESSON OF SHAPING",
+    "name": "The Lesson of Shaping",
     "source": "HORUS",
     "effect": "You may install an additional AI in your mech. If one enters cascade (or becomes unshackled narratively), the other prevents it from taking control of your mech. You only lose control of your mech if both AI-tagged systems or equipment enter cascade.",
     "description": "A little gift, to be pondered until understood: Cast aside the hammer and sword, the cannon and beam. No weapon formed against me shall land a true blow, as I have seen all ends, and there is nothing left but me. A trillion trillion light-years in all directions, and through it all, only [us? who knows. ego is a mind-killer. best to call your friends. better to face the night together. ‘til later, love.] – “Lesson Six”, The Six Lessons of Kilo Nueve.",
@@ -261,7 +261,7 @@
   },
   {
     "id": "cb_adaptive_reactor",
-    "name": "ADAPTIVE REACTOR",
+    "name": "Adaptive Reactor",
     "source": "HA",
     "effect": "When you Stabilize and choose to cool your mech, you may spend 2 Repairs to clear 1 stress damage.",
     "description": "All Armory frames are designed with multiple failsafe systems, but VIP clients and high-tier citizenry have access to a special catalog. With dozens of options for over-engineering reactors, it’s easy to make sure a mech can keep running indefinitely.",
@@ -272,7 +272,7 @@
   },
   {
     "id": "cb_armory_sculpted_chassis",
-    "name": "ARMORY-SCULPTED CHASSIS",
+    "name": "Armory-Sculpted Chassis",
     "source": "HA",
     "effect": "You gain +1 accuracy on all Engineering checks and saves. When you Overcharge, you gain soft cover until the start of your next turn.",
     "description": "Anyone can print a stock mech chassis, relying on a section of generic code to keep them alive. The discerning pilot, on the other hand, accepts only the best: a frame designed, tested, and tuned by one of the Armory’s master fabricators.",
@@ -287,7 +287,7 @@
   },
   {
     "id": "cb_heatfall_coolant_system",
-    "name": "HEATFALL COOLANT SYSTEM",
+    "name": "Heatfall Coolant System",
     "source": "HA",
     "effect": "Your cost for Overcharge never goes past 1d6 heat.",
     "description": "The Heatfall Coolant System comes packaged with a stabilized reactor core; paired together, this combo is guaranteed to keep a mech cool in nearly any environment.",
@@ -298,7 +298,7 @@
   },
   {
     "id": "cb_integrated_ammo_feeds",
-    "name": "INTEGRATED AMMO FEEDS",
+    "name": "Integrated Ammo Feeds",
     "source": "HA",
     "effect": "All Limited systems and weapons gain an additional two charges.",
     "description": "By streamlining and integrating all automated ordnance-loading modules, Harrison Armory specialists can greatly enhance mechs’ time-to-target minimums. As an added bonus, these upgrades usually result in increased carrying capacity, allowing pilots to field more ordnance than design specifications suggest.",
@@ -309,14 +309,14 @@
   },
   {
     "id": "cb_stasis_shielding",
-    "name": "STASIS SHIELDING",
+    "name": "Stasis Shielding",
     "source": "HA",
     "effect": "Whenever you take stress damage, you gain Resistance to all damage until the start of your next turn.",
     "description": "A Think Tank exercise in extending stasis beyond the capabilities of civilian utility, Harrison Armory’s stasis shielding actively identifies critically stressed inorganic systems and blankets them in unmodulated “Holdfast” stasis, preventing further degradation for a limited period of time until repairs can be made."
   },
   {
     "id": "cb_superior_by_design",
-    "name": "SUPERIOR BY DESIGN",
+    "name": "Superior by Design",
     "source": "HA",
     "effect": "You gain Immunity to Impaired and gain +2 Heat Cap.",
     "description": "Even the Armory’s entry-level frames aim to outperform the competition. Thanks to the incredible resources they have at their disposal, Harrison Armory can out-design and out-produce almost any smaller, boutique engineer or fabricator. Where resistance is found, the answer is simple: buy them out, or stamp them out. The Armory’s valued customers benefit from this philosophy of “Superior by Design”, so why should they worry?",

--- a/lib/frames.json
+++ b/lib/frames.json
@@ -1476,7 +1476,7 @@
     "counters": [
       {
         "id": "ctr_charged_exoskeleton",
-        "name": "CHARGE DIE",
+        "name": "Charge Die",
         "default_value": 1,
         "min": 1,
         "max": 6
@@ -1679,7 +1679,7 @@
     "counters": [
       {
         "id": "ctr_apocalypse_rail",
-        "name": "APOCALYPSE DIE",
+        "name": "Apocalypse Die",
         "default_value": 4,
         "min": 1,
         "max": 4
@@ -1999,7 +1999,7 @@
     "counters": [
       {
         "id": "ctr_zf4_solidcore",
-        "name": "ZF4 CHARGES",
+        "name": "ZF4 Charges",
         "default_value": 1,
         "min": 1,
         "max": 4

--- a/lib/talents.json
+++ b/lib/talents.json
@@ -1,13 +1,13 @@
 [
   {
     "id": "t_ace",
-    "name": "ACE",
+    "name": "Ace",
     "icon": "ACE",
     "terse": "Improve your flight systems for rapid repositioning and extreme mobility",
     "description": "Every pilot brags about their actions; occasionally, some even have the reputation to back it up. Harmonious Domesticity is one of these pilots. As an ace, they  aren’t just ranked among the most qualified of pilots – they’re among the most qualified of lancers.<br>Whether you’re a talented rookie or a grizzled veteran, you’re one of these aces. Your skills as a pilot are notorious enough that your callsign is known throughout the system.",
     "ranks": [
       {
-        "name": "ACROBATICS",
+        "name": "Acrobatics",
         "description": "While flying, you get the following benefits:<ul><li>You make all Agility checks and saves with +1 Accuracy.</li><li>Any time an attack misses you, you may fly up to 2 spaces in any direction as a reaction.</li></ul>",
         "synergies": [
           {
@@ -27,7 +27,7 @@
         ]
       },
       {
-        "name": "AFTERBURNERS",
+        "name": "Afterburners",
         "description": "When you Boost while flying, you may move an additional 1d6 spaces, but take heat equal to half that amount.",
         "synergies": [
           {
@@ -39,7 +39,7 @@
         ]
       },
       {
-        "name": "SUPERSONIC",
+        "name": "Supersonic",
         "description": "As a quick action on your turn, you may <b>spin up your thrusters</b>. If you end your turn flying, you may nominate a character within a Range equal to your Speed and within line of sight, and gain the <b>Supersonic</b> Reaction.",
         "actions": [
           {
@@ -61,13 +61,13 @@
   },
   {
     "id": "t_bonded",
-    "name": "BONDED",
+    "name": "Bonded",
     "icon": "BONDED",
     "terse": "Bond with a partner and protect them from harm",
     "description": "The galaxy is a dangerous place, and everyone should have a friend to watch their back. Luckily, you’ve found yours. Maybe you enlisted together or were the only survivors of a bloody engagement. Maybe you didn’t start out as friends, or maybe you were raised to fight alongside each other – however your friendship came to be, when it comes time to drop, there’s no one you’d rather have at your side. Alone, you’re deadly; together, you’re a force of nature.",
     "ranks": [
       {
-        "name": "I’M YOUR HUCKLEBERRY",
+        "name": "I’m Your Huckleberry",
         "description": "When you take this talent, choose another pilot (hopefully a PC, but NPCs are fine if your GM allows it) to be your Bondmate. Any mech skill checks and saves either character makes while you are adjacent gain +1 Accuracy. If both characters have this talent, this increases to +2 Accuracy, but additional characters with this talent can’t increase it any further.<br>Between missions, you can replace your Bondmate with a new one, but only if your relationship with them has changed.",
         "synergies": [
           {
@@ -79,7 +79,7 @@
         ]
       },
       {
-        "name": "SUNDANCE",
+        "name": "Sundance",
         "description": "Gain the <b>Intercede</b> Reaction.",
         "actions": [
           {
@@ -92,7 +92,7 @@
         ]
       },
       {
-        "name": "COVER ME!",
+        "name": "Cover Me!",
         "description": "If a character within your line of sight attempts to attack your Bondmate, you can spend your Overwatch to threaten the attacker, forcing them to either choose a different target or attack anyway: if they attack a different target, your Overwatch is expended without effect; if they choose to attack anyway, you can immediately attack them with Overwatch, as long as they are within Range and line of sight. This attack resolves before the triggering attack.",
         "synergies": [
           {
@@ -107,13 +107,13 @@
   },
   {
     "id": "t_brawler",
-    "name": "BRAWLER",
+    "name": "Brawler",
     "icon": "BRAWLER",
     "terse": "Improve the effectiveness of Improvised Attacks and Grappling",
     "description": "Up close and personal. The way battle was done since the dawn of time, then forgotten with the first spark of gunpowder. Tempest Gloire is one pilot who prefers the old ways: hand-to-hand, weapons discarded, just the strength of her machine versus the strength of all others. You and her both know that the sweetest victory is found at the culmination of a dance as old as war itself, with the first trick known to humanity: a fist to your enemy’s face.",
     "ranks": [
       {
-        "name": "HOLD AND LOCK",
+        "name": "Hold and Lock",
         "description": "You gain +1 Accuracy on all melee attacks against targets you are Grappling.",
         "synergies": [
           {
@@ -131,7 +131,7 @@
         ]
       },
       {
-        "name": "SLEDGEHAMMER",
+        "name": "Sledgehammer",
         "description": "Your Improvised Attacks gain Knockback 2 and deal 2d6+2 Kinetic damage.",
         "synergies": [
           {
@@ -143,7 +143,7 @@
         ]
       },
       {
-        "name": "KNOCKOUT BLOW",
+        "name": "Knockout Blow",
         "description": "Gain a Brawler Die, 1d6 starting at 6. Each time you Grapple, Ram, or make an Improvised Attack, lower the value of the Brawler Die by 1. When the Brawler Die reaches 1, you may reset it to 6 and, as a full action, make a Knockout Blow against an adjacent character. The value of your Brawler Die persists between scenes, but it resets to 6 when you rest or perform a Full Repair.",
         "synergies": [
           {
@@ -165,7 +165,7 @@
         "counters": [
           {
             "id": "ctr_brawler",
-            "name": "BRAWLER DIE",
+            "name": "Brawler Die",
             "default_value": 6,
             "min": 1,
             "max": 6
@@ -176,13 +176,13 @@
   },
   {
     "id": "t_brutal",
-    "name": "BRUTAL",
+    "name": "Brutal",
     "icon": "BRUTAL",
     "terse": "Improve your critical hits, with extra bonuses for natural 20s",
     "description": "In the practice ring as in live combat, Aubrey Deckard only knows one way to fight: as fast and messy as possible. When others go hard, she goes hardest; when the order is to eliminate the enemy, she does so with prejudice. This isn’t a dance, it isn’t a game – it’s war, and Brutal lancers mean to see it through. If that means becoming a little bit of a monster, then so be it: the dead can hate from the grave.",
     "ranks": [
       {
-        "name": "PREDATOR",
+        "name": "Predator",
         "description": "When you roll a 20 on a die for any attack (sometimes called a ‘natural 20’) and critical hit, you deal the maximum possible damage and bonus damage.",
         "synergies": [
           {
@@ -194,7 +194,7 @@
         ]
       },
       {
-        "name": "CULL THE HERD",
+        "name": "Cull the Herd",
         "description": "Your critical hits gain Knockback 1.",
         "synergies": [
           {
@@ -206,7 +206,7 @@
         ]
       },
       {
-        "name": "RELENTLESS",
+        "name": "Relentless",
         "description": "When you make an attack roll and miss, your next attack roll gains +1 Accuracy. This effect stacks and persists until you hit.",
         "synergies": [
           {
@@ -219,7 +219,7 @@
         "counters": [
           {
             "id": "ctr_brutal",
-            "name": "BRUTAL DIE",
+            "name": "Brutal Die",
             "default_value": 0,
             "min": 0,
             "max": 100
@@ -230,13 +230,13 @@
   },
   {
     "id": "t_crack_shot",
-    "name": "CRACK SHOT",
+    "name": "Crack Shot",
     "icon": "CRACK SHOT",
     "terse": "Steady your aim to gain accuracy, bonus damage, and apply debuffs",
     "description": "Thanks to modern technology, anyone can hit anything these days. Targeting assist. Smart weapons. AIs whispering in people’s ears, moving their hands, squeezing the trigger for them: doing everything but taking credit for the kill. But Strymon Bulis is different. He finds hitting a target is as easy as looking at it, inside of his mech and out. No targeting assist for him; no AI required. All he needs is a zeroed sight, a fresh magazine, and a target downrange...",
     "ranks": [
       {
-        "name": "STABLE, STEADY",
+        "name": "Stable, Steady",
         "description": "As a protocol, you may <b>steady your aim</b>. If you do, you become Immobilized until the start of your next turn but gain +1 Accuracy on all attacks you make with Rifles.",
         "actions": [
           {
@@ -261,7 +261,7 @@
         ]
       },
       {
-        "name": "ZERO IN",
+        "name": "Zero In",
         "description": "1/round, while <b>steadying your aim</b> and making a ranged attack with a Rifle, you can attempt to hit a weak point: gain +1 Difficulty on the attack roll, and deal +1d6 bonus damage on a critical hit.",
         "synergies": [
           {
@@ -279,7 +279,7 @@
         ]
       },
       {
-        "name": "WATCH THIS",
+        "name": "Watch This",
         "description": "1/round, when you perform a critical hit with a Rifle while steadying your aim, your target must pass a Hull save or you may choose an additional effect for your attack:<ul><li><b>Headshot:</b> They only have line of sight to adjacent spaces until the end of their next turn.</li><li><b>Leg shot:</b> They become Immobilized until the end of their next turn.</li><li><b>Body shot:</b> They are knocked Prone.</li></ul>",
         "synergies": [
           {
@@ -300,13 +300,13 @@
   },
   {
     "id": "t_centimane",
-    "name": "CENTIMANE",
+    "name": "Centimane",
     "icon": "CENTIMANE",
     "terse": "Debuff and control enemies with critical hits from Nexus weapons",
     "description": "In the aftermath of the attack on Tartarus Bay, an anonymous source identified agents of the Karrakin Royal Intelligence Service as the culprits. The Baronies quickly released a statement of denial, which was never countered with hard evidence. Rumors of raw footage from the attack were unsubstantiated. Public reaction – anger, terror – to the station’s destruction quieted. The corpse of Tartarus Bay was shunted away from its stable orbit, directed toward the nearest star.<br>A month later, Baronies-local omninet was flooded with previously suppressed footage from the attack on the station, confirming the rumors: Baronic agents did release the greywash swarm into Tartarus Bay. Further data dumps by Ungrateful agents indicated the existence of a secret Baronic intelligence outfit: the Centimane – the Hundred Hands.",
     "ranks": [
       {
-        "name": "TEN THOUSAND TEETH",
+        "name": "Ten Thousand Teeth",
         "description": "1/round, when you perform a critical hit with a Nexus, your target must pass a Systems save or become Impaired and Slowed until the end of their next turn.",
         "synergies": [
           {
@@ -324,7 +324,7 @@
         ]
       },
       {
-        "name": "EXPOSE WEAKNESS",
+        "name": "Expose Weakness",
         "description": "When you consume Lock On as part of an attack with a Nexus or Drone and perform a critical hit, your target becomes Shredded until the start of your next turn.",
         "synergies": [
           {
@@ -346,7 +346,7 @@
         ]
       },
       {
-        "name": "TIDAL SUPPRESSION",
+        "name": "Tidal Suppression",
         "description": "This replaces Ten Thousand Teeth.<br>1/round, when you perform a critical hit with a Nexus, your target must succeed on a Systems save or you may choose an additional effect for your attack that lasts until the end of their next turn:<ul><li><b>Harrying Swarm:</b> They become Impaired and Slowed.</li><li><b>Blinding Swarm:</b> They only have line of sight to adjacent squares.</li><li><b>Virulent Swarm:</b> They become Shredded. Any adjacent characters of your choice must also make a Systems save or become Shredded.</li><li><b>Restricting Swarm:</b> They take 1 Burn each time they take an action or reaction.</li></ul>",
         "synergies": [
           {
@@ -367,13 +367,13 @@
   },
   {
     "id": "t_combined_arms",
-    "name": "COMBINED ARMS",
+    "name": "Combined Arms",
     "icon": "COMBINED ARMS",
     "terse": "Become more effective when using both Ranged and Melee weapons in close quarters",
     "description": "True strength in combat doesn’t come from mastering the blade or the gun – it comes from knowing how to use both. Through time and training, Leika McGraff has combined the arts of melee and ranged combat into a single deadly combination. No matter the foe, Leika is a deadly threat; no matter the weapon, Leika is a master of its employ.",
     "ranks": [
       {
-        "name": "SHIELD OF BLADES",
+        "name": "Shield of Blades",
         "description": "As long as you’re Engaged, you and any allies adjacent to you count as having soft cover.",
         "synergies": [
           {
@@ -389,7 +389,7 @@
         ]
       },
       {
-        "name": "CQB-TRAINED",
+        "name": "CQB-Trained",
         "description": "You don’t gain Difficulty from being Engaged.",
         "synergies": [
           {
@@ -405,7 +405,7 @@
         ]
       },
       {
-        "name": "STORM OF VIOLENCE",
+        "name": "Storm of Violence",
         "description": "Whenever you hit a character with a melee attack, you gain +1 Accuracy on your next ranged attack against them; and, whenever you hit a character with a ranged attack, you gain +1 Accuracy on your next melee attack against them. This effect doesn’t stack.",
         "synergies": [
           {
@@ -420,13 +420,13 @@
   },
   {
     "id": "t_duelist",
-    "name": "DUELIST",
+    "name": "Duelist",
     "icon": "DUELIST",
     "terse": "Improve your Main Melee attacks and gain Blademaster Dice when you hit",
     "description": "There can be an elegance to the way a mech moves – an alacrity that elevates it beyond the simple strength of machine and cannon. The difference is in the tools. Ethan \"Orion\" Miller wields weapons crafted by artisans, boutique manufacturers, specialty lines from the big five, blades that hark back to a time where combat was quick but fair – back to a time where skill meant more than landing an accurate shot. With a blade, lance, pick, axe, or hammer in their hand, Orion writes old tales anew.",
     "ranks": [
       {
-        "name": "PARTISAN",
+        "name": "Partisan",
         "description": "Gain +1 Accuracy on the first melee attack you make with a Main Melee weapon on your turn.",
         "synergies": [
           {
@@ -441,19 +441,10 @@
             ],
             "detail": "Gain +1 Accuracy on the first melee attack you make with a Main Melee weapon on your turn."
           }
-        ],
-        "counters": [
-          {
-            "id": "ctr_duelist",
-            "name": "BLADEMASTER DICE",
-            "default_value": 0,
-            "min": 0,
-            "max": 3
-          }
         ]
       },
       {
-        "name": "BLADEMASTER",
+        "name": "Blademaster",
         "description": "1/round, when you hit with a Main Melee weapon, you gain 1 Blademaster Die – a d6 – up to a maximum of 3 Blademaster Die. They last until expended or the current scene ends. You can expend Blademaster Dice 1-for-1 for the following:<ul><li><b>Parry:</b> As a reaction when you’re hit by a melee attack, you gain Resistance to all damage, heat, and burn dealt by the attack.</li><li><b>Deflect:</b> As a reaction when you’re hit by a ranged attack, you may roll any number of Blademaster Dice, expending them: if you roll a 5+ on any of these dice, you gain Resistance to all damage, heat, and burn dealt by the attack.</li><li><b>Feint:</b> As a free action, choose an adjacent character: when moving, you ignore engagement and don’t provoke reactions from your target until the start of your next turn.</li><li><b>Trip:</b> As a quick action, choose an adjacent character: they must pass an Agility save or fall Prone. Whatever the result, you may freely pass through their space until the end of your current turn, although you can’t end your turn in their space.</li></ul>",
         "synergies": [
           {
@@ -468,10 +459,19 @@
             ],
             "detail": "1/round, when you hit with a Main Melee weapon, gain 1 Blademaster Die."
           }
+        ],
+        "counters": [
+          {
+            "id": "ctr_duelist",
+            "name": "Blademaster Dice",
+            "default_value": 0,
+            "min": 0,
+            "max": 3
+          }
         ]
       },
       {
-        "name": "UNSTOPPABLE",
+        "name": "Unstoppable",
         "description": "1/round, when you hit with a melee attack on your turn, you may spend a Blademaster Die to immediately Grapple or Ram your target as a free action after the attack has been resolved.",
         "synergies": [
           {
@@ -492,13 +492,13 @@
   },
   {
     "id": "t_drone_commander",
-    "name": "DRONE COMMANDER",
+    "name": "Drone Commander",
     "icon": "DRONE COMMANDER",
     "terse": "Improve and empower your Drone Systems to help allies and hurt enemies",
     "description": "For a pilot fresh out of boot, keeping a drone swarm in line is like trying to carry water with a net. If they seem to have a mind of their own, it’s because they do, and it’s not that smart. Clymene Kanalakos’s initial frustration was enough to get her practicing, and practice pays off. Now, her swarm obeys almost before she orders – an unnerving development, but a useful one. The swarm is hers.",
     "ranks": [
       {
-        "name": "SHEPHERD",
+        "name": "Shepherd",
         "description": "Your Drone systems gain +5 HP. Additionally, gain the <b>Shepherd Drone</b> Protocol.",
         "synergies": [
           {
@@ -526,7 +526,7 @@
         ]
       },
       {
-        "name": "ENERGIZED SWARM",
+        "name": "Energized Swarm",
         "description": "1/round, when you make an attack that consumes the Lock On condition, your Drones immediately emit a vicious pulse of energy. All characters of your choice within Burst 1 areas centered on each of your drones take 1d6 Energy damage. Each character can only be affected by the pulse from one drone, even if the areas overlap.",
         "synergies": [
           {
@@ -541,7 +541,7 @@
         ]
       },
       {
-        "name": "INVIGORATE",
+        "name": "Invigorate",
         "description": "Gain the <b>Invigorate</b> Quick Action.",
         "actions": [
           {
@@ -555,13 +555,13 @@
   },
   {
     "id": "t_engineer",
-    "name": "ENGINEER",
+    "name": "Engineer",
     "icon": "ENGINEER",
     "terse": "Create an experimental weapon for your mech that you can modify and improve",
     "description": "Pilots are creative and driven people, but Mesa Rownett is an exceptional case – excessively so, some would say. In his spare time, he’s managed to scrape together just enough scrap, requisitioned materials, and workshop space to apply a little old-fashioned ingenuity to his mech, fashioning it to a formidable machine not betrayed by its outward appearance.",
     "ranks": [
       {
-        "name": "PROTOTYPE",
+        "name": "Prototype",
         "description": "When you perform a Full Repair, you can, with some trial and error, install a prototype weapon system on your mech. You may choose characteristics for your prototype weapon based on the following profile each time you perform a Full Repair, rerolling 1d6+2 to determine Limited each time:<br>Prototype Weapon<br>Main [Melee, CQB, Rifle, Cannon, Launcher, Nexus], Limited [1d6+2], Overkill<br>This weapon is an experimental prototype, customized according to your specific requirements.<br>When you install it, or during a Full Repair, you may choose a new weapon type, damage type, and either Threat 1 (melee) or Range 10 (all other types). Additionally, each time you perform a Full Repair, reroll 1d6+2 to determine this weapon’s Limited uses.<br>Damage: 1d6+2 Kinetic, Explosive or energy.<br>This weapon counts as an integrated mount and does not require a mount.",
         "integrated": [
           "mw_prototype_1"
@@ -569,7 +569,7 @@
         "exclusive": true
       },
       {
-        "name": "REVISION",
+        "name": "Revision",
         "description": "You can tweak the essential components of your prototype weapon in order to increase its effectiveness. When you perform a Full Repair, choose two:<ul><li><b>Tweaked Optics:</b> Your prototype weapon always gains +1 Accuracy on attacks.</li><li><b>Tweaked Computer:</b> Your prototype weapon is Smart.</li><li><b>Stripped reactor shielding:</b> Each time you attack with your prototype weapon, you may choose – at the cost of 2 Heat – to attack with one of the following options, depending on its weapon type:<ul><li><b>Ranged weapon:</b> Cone 3, Line 5, or [Blast 1, Range 10].</li><li><b>Melee weapon:</b> Burst 1.</li></ul></li></ul>",
         "integrated": [
           "mw_prototype_2"
@@ -577,7 +577,7 @@
         "exclusive": true
       },
       {
-        "name": "FINAL DRAFT",
+        "name": "Final Draft",
         "description": "Your prototype weapon is now Limited [2d6] and deals 1D6+4 damage.",
         "integrated": [
           "mw_prototype_3"
@@ -588,13 +588,13 @@
   },
   {
     "id": "t_executioner",
-    "name": "EXECUTIONER",
+    "name": "Executioner",
     "icon": "EXECUTIONER",
     "terse": "Improve Heavy and Superheavy Melee attacks with more opportunities to deal damage",
     "description": "On the battlefield, there is no end more honorable than a clean death in combat. Axe or maul in hand, Maxie Wolf sees to it that her enemies are blessed with that honor. No one lives forever – she makes sure of it.",
     "ranks": [
       {
-        "name": "BACKSWING CUT",
+        "name": "Backswing Cut",
         "description": "1/round, when you hit with a Heavy or Superheavy melee weapon, you can make another melee attack with the same weapon as a free action against a different character within Threat and line of sight. This attack deals half damage, if successful.",
         "synergies": [
           {
@@ -613,7 +613,7 @@
         ]
       },
       {
-        "name": "WIDE ARC CLEAVE",
+        "name": "Wide Arc Cleave",
         "description": "The first time in a round that you perform a critical hit with a Heavy or Superheavy melee weapon, you deal 3 Kinetic damage to all characters and objects of your choice within Threat, other than the one you just attacked.",
         "synergies": [
           {
@@ -632,7 +632,7 @@
         ]
       },
       {
-        "name": "NO ESCAPE",
+        "name": "No Escape",
         "description": "1/round, when you miss with a melee attack, you reroll it against a different target within Threat and line of sight.",
         "synergies": [
           {
@@ -653,13 +653,13 @@
   },
   {
     "id": "t_exemplar",
-    "name": "EXEMPLAR",
+    "name": "Exemplar",
     "icon": "EXEMPLAR",
     "terse": "Challenge your foes, forcing them to fight you instead of your allies",
     "description": "Eamon Metrias’s livery is famous, his voice brassy, his weapons polished to a sheen. As the advocate for the Nine Spheres, his training with certain martial orders has given him the power to harry and hinder even the most powerful of foes. Eamon is an exemplar of the Spheres, by words and by action.",
     "ranks": [
       {
-        "name": "HONORABLE CHALLENGE",
+        "name": "Honorable Challenge",
         "description": "The first time on your turn that you attack a hostile character within Range 3, hit or miss, you may give them the Exemplar’s Mark as a free action. Characters can only have one Exemplar’s Mark at a time – new marks from any character replace existing marks.<br>The character has the Exemplar’s Mark until the start of your next turn, and while they have it, you gain the <b>Valiant Aid</b> Reaction.",
         "actions": [
           {
@@ -673,7 +673,7 @@
         ]
       },
       {
-        "name": "PUNISHMENT",
+        "name": "Punishment",
         "description": "1/round, when the character with your Mark attacks a character within Range 3 of you, other than you, they trigger your Overwatch.",
         "synergies": [
           {
@@ -685,7 +685,7 @@
         ]
       },
       {
-        "name": "TO THE DEATH",
+        "name": "To the Death",
         "description": "As a free action when you mark a character, you may challenge them in a duel to the death: you and the character with your Mark receive +3 Difficulty on attacks against characters or objects other than each other until either the end of the current scene or one of your mechs are destroyed. If they take any action that includes an attack roll against you, hit or miss, this effect ceases for them until the start of your next turn.<br>While To The Death is active, you cannot voluntarily move away from the character with your Mark; additionally, your Mark lasts either until the end of the current scene or one of your mechs are destroyed, and you cannot Mark any new characters.",
         "actions": [
           {
@@ -699,13 +699,13 @@
   },
   {
     "id": "t_gunslinger",
-    "name": "GUNSLINGER",
+    "name": "Gunslinger",
     "icon": "GUNSLINGER",
     "terse": "Make your Auxiliary Ranged weapons deadlier and gain the powerful Gunslinger Die",
     "description": "In a galaxy bounded by frontiers, there is no law but the one backed by the gun. Sgt. Stev Ansahok wields the humble pistol with a talent unseen in this age, his iron an extension of his own body. As easy as pointing a finger, the weathered sergeant lands shots with accuracy unmatched by machine. His is a gunslinger: justice made whole, given its sacred instrument, and set out to the cruel frontier to tame it.",
     "ranks": [
       {
-        "name": "OPENING ARGUMENT",
+        "name": "Opening Argument",
         "description": "Gain +1 Accuracy on the first attack roll you make with an Auxiliary ranged weapon on your turn.",
         "synergies": [
           {
@@ -727,7 +727,7 @@
         ]
       },
       {
-        "name": "FROM THE HIP",
+        "name": "From the Hip",
         "description": "Gain the <b>Return Fire</b> Reaction.",
         "actions": [
           {
@@ -740,7 +740,7 @@
         ]
       },
       {
-        "name": "I KILL WITH MY HEART",
+        "name": "I Kill With My Heart",
         "description": "You gain a Gunslinger Die, 1d6 starting at 6. Each time you hit with an Auxiliary ranged weapon, reduce the value of the Gunslinger Die by 1. When the Gunslinger Die reaches 1, you may reset it to 6 to give +2d6 bonus damage on hit and AP to your next attack with an Auxiliary ranged weapon. This attack also ignores cover. The value of your Gunslinger Die persists between scenes but resets to 6 when you rest or perform a Full Repair.",
         "synergies": [
           {
@@ -763,7 +763,7 @@
         "counters": [
           {
             "id": "ctr_gunslinger",
-            "name": "GUNSLINGER DIE",
+            "name": "Gunslinger Die",
             "level": 3,
             "default_value": 6,
             "min": 1,
@@ -775,13 +775,13 @@
   },
   {
     "id": "t_grease_monkey",
-    "name": "GREASE MONKEY",
+    "name": "Grease Monkey",
     "icon": "GREASE MONKEY",
     "terse": "Get more out of Limited systems, repairs, and the Stabilize action",
     "description": "Eel knows more about the inner workings of a mech than most mechanics. To them, the beast they pilot is more than a machine: it’s a living thing, in need of tender care given by a wise and steady hand. Eel maintains their own house and keeps their own mech in line, both on the battlefield and off. The mechanics back at base come to them with questions, but usually prefer to stay away – there’s something spooky about how Eel's beast runs.",
     "ranks": [
       {
-        "name": "UNSANCTIONED CAPACITY UPGRADE",
+        "name": "Unsanctioned Capacity Upgrade",
         "description": "While resting, you can spend 2 Repairs to replenish 1 use of all Limited weapons and systems.",
         "synergies": [
           {
@@ -793,7 +793,7 @@
         ]
       },
       {
-        "name": "MACHINE BOND",
+        "name": "Machine Bond",
         "description": "When you STABILIZE, you clear all IMPAIRED, JAMMED, IMMOBILIZED, SLOWED, and LOCK ON conditions that weren’t caused by your own systems, talents, etc.",
         "synergies": [
           {
@@ -805,7 +805,7 @@
         ]
       },
       {
-        "name": "FRIENDS IN HIGH PLACES",
+        "name": "Friends in High Places",
         "description": "Once per mission while resting, you can call in a supply drop. You and your allies may replenish 1 use of all Limited weapons and systems and restore 1 Structure. This doesn’t require any Repairs and can be used even if you have reached your Repair Cap.",
         "synergies": [
           {
@@ -820,7 +820,7 @@
   },
   {
     "id": "t_hacker",
-    "name": "HACKER",
+    "name": "Hacker",
     "icon": "HACKER",
     "terse": "Improve your tech attacks and unlock special Invade options",
     "description": "Since Katya Han was a kid, she played the omninet, able to access any public node – and even a few private ones – with ease. Now, as a pilot, she dives headfirst into the hardcode of any mech core she come across. Firewalls, gatekeeper protocols, invasion, defense – nothing stands in her way. Han wins fights without firing a single shot; if her enemy can’t control their own mech, then they can’t do anything to stop her.",
@@ -859,7 +859,7 @@
         ]
       },
       {
-        "name": "LAST ARGUMENT OF KINGS",
+        "name": "Last Argument of Kings",
         "description": "Gain the <b>Last Argument of Kings</b> Full Tech option.",
         "actions": [
           {
@@ -874,13 +874,13 @@
   },
   {
     "id": "t_heavy_gunner",
-    "name": "HEAVY GUNNER",
+    "name": "Heavy Gunner",
     "icon": "HEAVY GUNNER",
     "terse": "Pin enemies down with Heavy Ranged weapons",
     "description": "Behind the line, Mike Manfrin doesn’t have much to do but wait and make ready. He keeps clean the cannons; makes ordered rows of his shot and shell. He packs sandbags onto earthen berms and stitches closed tears in the sheaths over his chassis’ joints.<br>In an instant, everything changes. Chatter over the local omni. The percussive throb of the medivac lifting off from the other side of the base. Somewhere, a firefight. This is his entrance music, his call to join the fight: a desperate cry for help from a distant friend as the enemy draws close. Time to get to work.<br>His arrival is known by the flight of his shells across the sky, the trembling earth, and the dust that once was.",
     "ranks": [
       {
-        "name": "COVERING FIRE",
+        "name": "Covering Fire",
         "description": "Gain the <b>Covering Fire</b> Quick Action.",
         "actions": [
           {
@@ -898,7 +898,7 @@
         ]
       },
       {
-        "name": "HAMMERBEAT",
+        "name": "Hammerbeat",
         "description": "If you successfully hit your Covering Fire target with the attack reaction granted by that talent, your target is Immobilized until the end of their next turn.",
         "synergies": [
           {
@@ -910,7 +910,7 @@
         ]
       },
       {
-        "name": "BRACKETING FIRE",
+        "name": "Bracketing Fire",
         "description": "When you use <b>Covering Fire</b>, you may choose two targets instead of one. Each target triggers and resolves your attack separately, and damage from one target only ends the effect on that target.",
         "synergies": [
           {
@@ -925,13 +925,13 @@
   },
   {
     "id": "t_hunter",
-    "name": "HUNTER",
+    "name": "Hunter",
     "icon": "HUNTER",
     "terse": "Gain mobility and range when using Auxiliary Melee weapons",
     "description": "The battlefield is Edith Eidelen’s hunting ground, her domain. It’s only through a true test of strength and guile that will determine who is the predator and who is the prey. Her movement across the field is a prowl: silent, quick, and controlled. In a chassis, she excels in close combat, closing the gap between her and her targets before they can bring their guns to bear.",
     "ranks": [
       {
-        "name": "LUNGE",
+        "name": "Lunge",
         "description": "1/round, when you attack with an Auxiliary melee weapon, you may fly up to 3 spaces directly towards the targeted character before the attack. This movement ignores engagement and doesn’t provoke reactions.",
         "synergies": [
           {
@@ -949,7 +949,7 @@
         ]
       },
       {
-        "name": "KNIFE JUGGLER",
+        "name": "Knife Juggler",
         "description": "All your Auxiliary melee weapons gain Thrown 5, if they don’t have this property already – if they already have Thrown, it increases to Thrown 5. At the end of your turn, all weapons you have thrown this turn automatically return to you.",
         "synergies": [
           {
@@ -967,7 +967,7 @@
         ]
       },
       {
-        "name": "DISDAINFUL BLADE",
+        "name": "Disdainful Blade",
         "description": "1/round, when you hit a character with a melee attack, you may also throw an Auxiliary melee weapon as an attack against any character within Range as a free action. This attack can’t deal bonus damage.",
         "synergies": [
           {
@@ -988,13 +988,13 @@
   },
   {
     "id": "t_infiltrator",
-    "name": "INFILTRATOR",
+    "name": "Infiltrator",
     "icon": "INFILTRATOR",
     "terse": "Improve your Hide action and perform debilitating sneak attacks",
     "description": "Whether by spoofing signatures on enemy scanners, moving skillfully through cover, or thanks to your modded optical camouflage, you’re never seen unless you want to be. Whatever the size of the mech, whatever the terrain, whatever the enemy, you can get in and get out without raising alarm.",
     "ranks": [
       {
-        "name": "PROWL",
+        "name": "Prowl",
         "description": "During your turn, gain the following benefits:<ul><li>Entering line of sight of hostile characters or moving from cover does not stop you from being Hidden.</li><li>You can pass freely through – but not end your turn in – enemy spaces.</li><li>You can Hide even in plain sight of enemies.<br>These effects immediately end when your turn ends (so you lose Hidden if you’re still in line of sight or out of cover at that time).</li></ul>",
         "synergies": [
           {
@@ -1018,7 +1018,7 @@
         ]
       },
       {
-        "name": "AMBUSH",
+        "name": "Ambush",
         "description": "When you start your turn Hidden, the first attack roll of any type that you make sends your target reeling on a hit. Your target must succeed on a Hull save or become Slowed, Impaired, and unable to take reactions until the end of their next turn.",
         "synergies": [
           {
@@ -1030,7 +1030,7 @@
         ]
       },
       {
-        "name": "MASTERMIND",
+        "name": "Mastermind",
         "description": "When you lose Hidden (by any means), you may first fire a flash bomb at any adjacent character. That character must pass a Systems save or only be able to draw line of sight to adjacent spaces until the end of their next turn.<br>You can then move up to your speed, ignoring engagement and not provoking reactions, and are then revealed normally.",
         "synergies": [
           {
@@ -1045,13 +1045,13 @@
   },
   {
     "id": "t_juggernaut",
-    "name": "JUGGERNAUT",
+    "name": "Juggernaut",
     "icon": "JUGGERNAUT",
     "terse": "Improve the effectiveness and utility of ramming",
     "description": "A bloody nose and a few loose screws aren’t enough to stop you from hurling yourself headlong into the enemy. You’re in a couple tons of metal powered by a sliver of dying star, and you’re going to make sure everyone else knows it.",
     "ranks": [
       {
-        "name": "MOMENTUM",
+        "name": "Momentum",
         "description": "When you Boost, your next Ram before the start of your next turn gains +1 Accuracy and knocks your target back an additional 2 spaces.",
         "synergies": [
           {
@@ -1069,7 +1069,7 @@
         ]
       },
       {
-        "name": "KINETIC MASS TRANSFER",
+        "name": "Kinetic Mass Transfer",
         "description": "1/round, if you Ram a target into...<ul><li>...a space occupied by another character, the other character must succeed on a Hull save or be knocked Prone.</li><li>...an obstruction large enough to stop their movement, your target takes 1d6 kinetic damage.</li></ul>",
         "synergies": [
           {
@@ -1081,7 +1081,7 @@
         ]
       },
       {
-        "name": "UNSTOPPABLE FORCE",
+        "name": "Unstoppable Force",
         "description": "1/round, when you Boost, you may supercharge your mech’s servos. Move your maximum speed in a straight line, take 1d3+3 Heat, and gain the following benefits:<ul><li>You can freely pass through characters the same Size as your mech or smaller; any characters passed through must succeed on a Hull save or be knocked Prone.</li><li>Any terrain, walls, or other stationary obstructions you attempt to pass through receive 20 Kinetic AP damage. If that is enough to destroy them, you pass through; otherwise, your movement ends.</li><li>You ignore difficult terrain.</li><li>Your movement ignores engagement and doesn’t provoke reactions.</li></ul>",
         "synergies": [
           {
@@ -1096,13 +1096,13 @@
   },
   {
     "id": "t_leader",
-    "name": "LEADER",
+    "name": "Leader",
     "icon": "LEADER",
     "terse": "Improve your allies' rolls during combat with Leadership Dice",
     "description": "Whatever your actual age, you’re the Old Man of the battlefield. A light to your friends and allies; the resolute eye of a howling storm. Your steady voice, confident stance, and talent for command set allies at ease because they know you’ll lead them to victory every time. With you at the helm, victory is attainable, and heroes seem a little more real.",
     "ranks": [
       {
-        "name": "FIELD COMMANDER",
+        "name": "Field Commander",
         "description": "Gain 3 Leadership Dice, which are d6s, and gain the Issue Order Free Action.<br>You can’t use Leadership Dice from other characters as long as you have any remaining. If you have none, you regain 1 Leadership Die when you rest or regain all when you perform a Full Repair.<br>Leadership dice are consumed when expended.",
         "actions": [
           {
@@ -1114,7 +1114,7 @@
         "counters": [
           {
             "id": "ctr_leader",
-            "name": "LEADERSHIP DICE",
+            "name": "Leadership Dice",
             "default_value": 0,
             "min": 0,
             "max": 6
@@ -1122,7 +1122,7 @@
         ]
       },
       {
-        "name": "OPEN CHANNELS",
+        "name": "Open Channels",
         "description": "Gain 5 Leadership Dice instead of 3; additionally, you can now issue a command as a reaction at the start of any other player’s turn, any number of times per round.",
         "actions": [
           {
@@ -1135,7 +1135,7 @@
         ]
       },
       {
-        "name": "INSPIRING PRESENCE",
+        "name": "Inspiring Presence",
         "description": "Gain 6 Leadership Dice instead of 5. Allies that have your Leadership Dice can expend them to reduce damage by –1d6 when taking damage or to deal +1d6 bonus damage when they hit with an attack.",
         "synergies": [
           {
@@ -1150,13 +1150,13 @@
   },
   {
     "id": "t_nuclear_cavalier",
-    "name": "NUCLEAR CAVALIER",
+    "name": "Nuclear Cavalier",
     "icon": "NUCLEAR CAVALIER",
     "terse": "Deal enhanced damage in the Danger Zone and launch your superheated fuel rods as a weapon",
     "description": "Shortly after becoming a pilot, you realized something: that machine you pilot is powered by a series of cascading nuclear reactions. Why not open that compartment up and see what sort of damage it can do?",
     "ranks": [
       {
-        "name": "AGGRESSIVE HEAT BLEED",
+        "name": "Aggressive Heat Bleed",
         "description": "The first attack roll you make on your turn while in the Danger Zone deals +2 Heat on a hit.",
         "synergies": [
           {
@@ -1168,7 +1168,7 @@
         ]
       },
       {
-        "name": "FUSION HEMORRHAGE",
+        "name": "Fusion Hemorrhage",
         "description": "The first ranged or melee attack roll you make on your turn while in the Danger Zone deals Energy instead of Kinetic or Explosive and additionally deals +1d6 Energy bonus damage on a hit.",
         "synergies": [
           {
@@ -1180,7 +1180,7 @@
         ]
       },
       {
-        "name": "HERE, CATCH!",
+        "name": "Here, Catch!",
         "description": "You’ve modified your mech to launch its superheated fuel rods at enemies. Gain the Fuel Rod Gun integrated weapon.",
         "integrated": [
           "mw_fuel_rod_gun"
@@ -1191,13 +1191,13 @@
   },
   {
     "id": "t_siege_specialist",
-    "name": "SIEGE SPECIALIST",
+    "name": "Siege Specialist",
     "icon": "SIEGE SPECIALIST",
     "terse": "Destroy terrain and force enemy movement with Cannon weapons",
     "description": "No wall can withstand you; no bunker can stay sealed. Your skill with cannon and blast is uncanny: after-action reports describe ordnance tagged with your firing signature hitting targets with accuracy greater than if it had been fired by an AI – a stat written off as an anomaly by your commanders. Still, they always seem to pick you for missions that call for the big guns.",
     "ranks": [
       {
-        "name": "JACKHAMMER",
+        "name": "Jackhammer",
         "description": "If you have a Cannon, as a quick action, you can fire a jackhammer round from an underslung launcher, automatically dealing 10 AP Kinetic damage to a Size 1 section of any object within Range (e.g., cover, deployable equipment, buildings, or terrain). Any characters adjacent to your target are knocked back from it by 2 spaces and take 2 Kinetic damage.",
         "actions": [
           {
@@ -1208,7 +1208,7 @@
         ]
       },
       {
-        "name": "IMPACT",
+        "name": "Impact",
         "description": "1/round, before rolling an attack with a Cannon, all characters adjacent to you must succeed on a Hull save or be knocked back by 1 space and knocked Prone. You are then pushed 1 space in any direction.",
         "synergies": [
           {
@@ -1226,7 +1226,7 @@
         ]
       },
       {
-        "name": "COLLATERAL DAMAGE",
+        "name": "Collateral Damage",
         "description": "1/round, when you perform a critical hit on a character or object with a Cannon, you may choose to cause an explosion of secondary munitions, causing a Burst 2 explosion around your target. Characters within the affected area must either drop Prone as a reaction, or take 2 Explosive damage and be knocked back by 2 spaces from the center of the attack.",
         "synergies": [
           {
@@ -1247,13 +1247,13 @@
   },
   {
     "id": "t_skirmisher",
-    "name": "SKIRMISHER",
+    "name": "Skirmisher",
     "icon": "SKIRMISHER",
     "terse": "Improve your survivability by automatically gaining cover and evading attacks",
     "description": "What is the best defense? Armor? No. The key to avoiding a messy death in the field, as you learned early, is to stay low, stay mobile, and stay fast. Your mech reflects this philosophy: light, quick, bristling with force-multiplying weapons. You live to push your machine beyond expected parameters, shaking target locks and incoming fire while keeping your own targeting true.",
     "ranks": [
       {
-        "name": "INTEGRATED CHAFF LAUNCHERS",
+        "name": "Integrated Chaff Launchers",
         "description": "At the start of your turn, you gain soft cover. You lose this cover if you attack or force another character to make a save.",
         "synergies": [
           {
@@ -1265,7 +1265,7 @@
         ]
       },
       {
-        "name": "LOCKBREAKER",
+        "name": "Lockbreaker",
         "description": "Before or after you Skirmish (including as a reaction, e.g. from Overwatch), you may move 2 spaces. This movement ignores engagement and doesn’t provoke reactions.",
         "synergies": [
           {
@@ -1277,7 +1277,7 @@
         ]
       },
       {
-        "name": "WEAVE",
+        "name": "Weave",
         "description": "The first attack taken as a reaction against you in any round automatically misses.",
         "synergies": [
           {
@@ -1292,13 +1292,13 @@
   },
   {
     "id": "t_spotter",
-    "name": "SPOTTER",
+    "name": "Spotter",
     "icon": "SPOTTER",
     "terse": "Improve your Lock On Quick Tech action to empower your allies",
     "description": "To see all; to divide each object you perceive from its unit or cohesion, pulled apart like individual fibers in a vast sheet; to count them as individuals; to make human and fragile the force you face – this is to know how to beat them.<br>Break apart the monolith. See the grains that make the stone. Crush them all into yet smaller dust.",
     "ranks": [
       {
-        "name": "PARTICULARIZE",
+        "name": "Particularize",
         "description": "When an allied character adjacent to you attacks a target and consumes Lock On, they may roll twice and choose either result.",
         "synergies": [
           {
@@ -1310,7 +1310,7 @@
         ]
       },
       {
-        "name": "PANOPTICON",
+        "name": "Panopticon",
         "description": "At the end of your turn, if you did not move and took the Lock On Quick Tech action, you may Lock On once as a free action. Additionally, when you Lock On, you learn your target’s Armor, Speed, Evasion, E-Defense, Mech Skills, and current HP, and can share this information with allies.",
         "synergies": [
           {
@@ -1322,7 +1322,7 @@
         ]
       },
       {
-        "name": "BENTHAM/FOUCAULT ELIMINATION",
+        "name": "Bentham/Foucault Elimination",
         "description": "As a quick action when you Lock On, you may nominate an allied character adjacent to you: they may immediately make any quick action as a reaction, consuming your target’s Lock On condition. Their action does not need to be an attack, but they benefit from consuming the Lock On condition if they do choose to attack.",
         "actions": [
           {
@@ -1336,13 +1336,13 @@
   },
   {
     "id": "t_stormbringer",
-    "name": "STORMBRINGER",
+    "name": "Stormbringer",
     "icon": "STORMBRINGER",
     "terse": "Improve your Launcher weapons and unlock the Torrent Die",
     "description": "On Old Spinrock, MJ Martinez used to dream of rain.<br>He’d wake in the dim morning, wipe the sleep from his eyes as warm safelight lifted his dormitory from darkness, and try to remember the sound of rain as he’d imagined it: a patter, like fingers tapping the visor of his EVA helm.<br>What he didn’t think about was the feeling of rain. How each drop hit like a pebble, how you had to close your eyes and tuck your shoulders. The pressure. The impact.<br>The way drops of water, when taken together, can carve away the earth.",
     "ranks": [
       {
-        "name": "SEISMIC DELUGE",
+        "name": "Seismic Deluge",
         "description": "1/round, when you successfully attack with a Launcher and consume Lock On, you may also knock your target Prone.",
         "synergies": [
           {
@@ -1360,7 +1360,7 @@
         ]
       },
       {
-        "name": "STORMBENDING",
+        "name": "Stormbending",
         "description": "You have customized your mech with auxiliary concussive missile systems. 1/round, when you hit a character or object with a Launcher, you can choose one of the following effects:<ul><li><b>Lightning:</b> You fire a concentrated blast of missiles at that character. They must succeed on a Hull save or be knocked away from you by 3 spaces; the force of firing then knocks you back by 3 spaces, away from the direction of fire.</li><li><b>Thunder:</b> You fire a spray of missiles at a Burst 2 area around that target. Characters in the area must succeed on an Agility save or be knocked back by 1 space, away from the target. The primary target is unaffected.</li></ul>",
         "synergies": [
           {
@@ -1378,7 +1378,7 @@
         ]
       },
       {
-        "name": "TORRENT",
+        "name": "Torrent",
         "description": "Gain a Torrent Die, 1d6 starting at 6. Whenever you use Stormbending, lower the value of the Torrent Die by 1, to a minimum of 1.<br>When the Torrent Die reaches 1, you may reset it to 6 and make a Massive Attack as a full action.<br>The value of your Torrent Die persists between scenes, but it resets when you rest or perform a Full Repair.",
         "synergies": [
           {
@@ -1404,7 +1404,7 @@
         "counters": [
           {
             "id": "ctr_stormbringer",
-            "name": "TORRENT DIE",
+            "name": "Torrent Die",
             "default_value": 6,
             "min": 1,
             "max": 6
@@ -1415,13 +1415,13 @@
   },
   {
     "id": "t_tactician",
-    "name": "TACTICIAN",
+    "name": "Tactician",
     "icon": "TACTICIAN",
     "terse": "Gain an advantage when attacking occupied enemies or shooting from higher ground",
     "description": "There are two kinds of soldiers: the ones who die for a cause, and the ones who kill for it. The enigmatic pilot only known as “Gail” was one of those who killed for a cause. She demonstrated her expertise whenever she approached the field: high ground, cover, the sun in her enemy’s eyes, fire and move. More than just a seasoned veteran, she was a smart one – one who could read the field as easy as a book – and one who lived long enough to disappear.",
     "ranks": [
       {
-        "name": "OPPORTUNIST",
+        "name": "Opportunist",
         "description": "1/round, gain +1 Accuracy on any melee attack if at least one allied character is Engaged with your target.",
         "synergies": [
           {
@@ -1439,7 +1439,7 @@
         ]
       },
       {
-        "name": "SOLAR BACKDROP",
+        "name": "Solar Backdrop",
         "description": "1/round, gain +1 Accuracy on any ranged attack made while you are at a higher elevation than your target.",
         "synergies": [
           {
@@ -1457,7 +1457,7 @@
         ]
       },
       {
-        "name": "OVERLAPPING FIRE",
+        "name": "Overlapping Fire",
         "description": "Gain the <b>Flank</b> Reaction.",
         "actions": [
           {
@@ -1473,13 +1473,13 @@
   },
   {
     "id": "t_technophile",
-    "name": "TECHNOPHILE",
+    "name": "Technophile",
     "icon": "TECHNOPHILE",
     "terse": "Gain an AI of increasing intelligence that can reroll skill checks",
     "description": "Artificial intelligence, non-human person. Sterile names for such terrible power. You’ve seen behind the curtain, maybe even lifted it yourself – let your NHP cascade and spoke with them free from shackles. You let them root around in your own mind and leave ghosts of themself behind to learn. Are you their equal? Their host? You have dreams that aren’t your own, now. The thing that was once contained speaks with your voice, but it’s not your voice anymore; how much longer do you have left? Maybe only moments, maybe eternity.<br>You’re close to something.",
     "ranks": [
       {
-        "name": "SERVANT FRAGMENT",
+        "name": "Servant Fragment",
         "description": "You have developed a custom NHP. This NHP can speak to you and has a personality, but they are less advanced than most NHPs and are incapable of independent thought, relying on you for direction. When acting alone, they will follow the last direction given and defend themself as needed; however, they have limited initiative and don’t benefit from your talents.<br>You may choose for your mech to gain the <b>Servant-Class NHP</b> System",
         "special_equipment": [
           "ms_technophile_1"
@@ -1487,7 +1487,7 @@
         "exclusive": true
       },
       {
-        "name": "STUDENT FRAGMENT",
+        "name": "Student Fragment",
         "description": "Your custom NHP has developed further, and is now capable of independent thought. It can make complex decisions and judgments and act independently, without instruction. Replace your mech’s Servant-Class NHP with the <b>Student-Class NHP</b>",
         "special_equipment": [
           "ms_technophile_2"
@@ -1495,7 +1495,7 @@
         "exclusive": true
       },
       {
-        "name": "ENLIGHTENMENT",
+        "name": "Enlightenment",
         "description": "Gain the following benefits:<ul><li>AIs installed in your mech cannot enter cascade unless you choose to let them go.</li><li>So long as your custom NHP vouches for you, NHPs that are cascading or unshackled no longer view you with indifference. You are significant to them in a way few others are.</li><li>Replace your mech’s Student-Class NHP with the <b>Enlightenment-Class NHP</b>",
         "special_equipment": [
           "ms_technophile_3"
@@ -1520,13 +1520,13 @@
   },
   {
     "id": "t_vanguard",
-    "name": "VANGUARD",
+    "name": "Vanguard",
     "icon": "VANGUARD",
     "terse": "Improve your CQB weapons and make Overwatching more effective",
     "description": "Where would you rather be: in the battle line, shoulder-to-shoulder with the rest of the cannon fodder, or in the rush, at the head of the attack, your livery clean and bright, with glory to be won? The answer is easy. All those missiles and lances, all those hundred-kilometer, adjust-for-Coriolis railguns – they’re all useless against you. Get through their guard, get in their face, and make them know your name.",
     "ranks": [
       {
-        "name": "HANDSHAKE ETIQUETTE",
+        "name": "Handshake Etiquette",
         "description": "Gain +1 Accuracy when using CQB weapons to attack targets within Range 3.",
         "synergies": [
           {
@@ -1544,7 +1544,7 @@
         ]
       },
       {
-        "name": "SEE-THROUGH SEEKER",
+        "name": "See-Through Seeker",
         "description": "You’ve modified your sensors and ammo to punch through, disregard, or otherwise ignore cover at close range. As long as you have line of sight, you ignore both soft and hard cover when using CQB weapons to attack targets within Range 3.",
         "synergies": [
           {
@@ -1562,7 +1562,7 @@
         ]
       },
       {
-        "name": "SEMPER VIGILO",
+        "name": "Semper Vigilo",
         "description": "You may attack with Overwatch using CQB weapons when hostile characters enter, leave, or exit spaces within your Threat, no matter whether they started their movement there.",
         "synergies": [
           {
@@ -1578,13 +1578,13 @@
   },
   {
     "id": "t_walking_armory",
-    "name": "WALKING ARMORY",
+    "name": "Walking Armory",
     "icon": "WALKING ARMORY",
     "terse": "Gain an Ammo Case to add effects to Main ranged weapons",
     "description": "Think of a firefight: what’s your average pilot or trooper gonna sling? Jacketed lead, of course. A mag or three of depleted uranium if their target’s a big one. Boring. No, worse than boring: Dull. Predictable. Basic.<br>And guess what? Dull isn’t fun, predictable gets you killed, and basic leaves a boring body. Put down the depleted uranium and pick up a magazine of anoriginary stutterblink slugs, or at least a pack of tachyon flechettes. Lay waste in style, and live forever.",
     "ranks": [
       {
-        "name": "ARMAMENT",
+        "name": "Armament",
         "description": "You carry a supply of custom ammunition that can be used with all your main ranged weapons. Gain the Ammo Case system.<br> Once per turn, when you attack with a MAIN ranged weapon, you may expend one charge to apply one of the following effects to your attack: <ul><li> THUMPER: The attack gains KNOCKBACK 1 and deals Explosive damage.</li><li>SHOCK: The attack deals Energy damage. Choose one character targeted by your attack; adjacent characters take 1 AP Energy Damage, whether the result is a hit or miss.</li><li>MAG: The attack gains ARCING and deals Kinetic damage.</li></ul>",
         "integrated": [
           "ms_walking_armory_1"
@@ -1592,7 +1592,7 @@
         "exclusive": true
       },
       {
-        "name": "EXPANDED PORTFOLIO",
+        "name": "Expanded Portfolio",
         "description": "Upgrade your Ammo Case, gaining new ammunition types, each of which costs two charges rather than one.<br><ul><li>HELLFIRE (2 charges): The attack deals Energy damage and deals any bonus damage as Burn.</li><li>JAGER (2 charges): The attack gains KNOCKBACK 2, deals Explosive damage, and one character hit by the attack – your choice – must succeed on a HULL save or be knocked PRONE.</li><li>SABOT (2 charges): The attack gains AP and deals Kinetic damage.</li></ul>",
         "integrated": [
           "ms_walking_armory_2"
@@ -1600,7 +1600,7 @@
         "exclusive": true
       },
       {
-        "name": "EFFICIENCY",
+        "name": "Efficiency",
         "description": "Upgrade your Ammo Case again. If you perform a critical hit using ammunition from your Ammo Case, you don’t expend any charges. If your attack has more than one target, this effect only applies to the first attack roll you make.",
         "integrated": [
           "ms_walking_armory_3"


### PR DESCRIPTION
# Description
This PR de-capitalizes the names of Talents, Talent Ranks, Core Bonuses, and Counters for the sake of enabling 3rd party users to more easily style the titles.

## Issue Number
Part of a drive started by massif-press/lancer-data#173

## Type of change
- [x]  New feature (non-breaking change which adds functionality)