### PR TITLE
fix(data): remove cheap_stress bonus from HA CB

### DIFF
--- a/lib/core_bonuses.json
+++ b/lib/core_bonuses.json
@@ -264,11 +264,7 @@
     "name": "Adaptive Reactor",
     "source": "HA",
     "effect": "When you Stabilize and choose to cool your mech, you may spend 2 Repairs to clear 1 stress damage.",
-    "description": "All Armory frames are designed with multiple failsafe systems, but VIP clients and high-tier citizenry have access to a special catalog. With dozens of options for over-engineering reactors, it’s easy to make sure a mech can keep running indefinitely.",
-    "bonuses": [{
-      "id": "cheap_stress",
-      "val": true
-    }]
+    "description": "All Armory frames are designed with multiple failsafe systems, but VIP clients and high-tier citizenry have access to a special catalog. With dozens of options for over-engineering reactors, it’s easy to make sure a mech can keep running indefinitely."
   },
   {
     "id": "cb_armory_sculpted_chassis",


### PR DESCRIPTION
# Description
This PR removes the Cheap Stress bonus from the HA Core Bonus, Adaptive Reactor.

## Issue Number
None currently.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)