### PR TITLE
fix Technophile 3 AI tag

### DIFF
--- a/lib/systems.json
+++ b/lib/systems.json
@@ -3371,6 +3371,9 @@
     "sp": 0,
     "tags": [
       {
+        "id": "tg_ai"
+      },
+      {
         "id": "tg_unique"
       },
       {


### PR DESCRIPTION
# Description
This adds the AI tag to the Enlightenment-class NHP from Technophile 3 as per the description:
> Your mech gains the AI tag; however, this NHP doesn’t count towards the number of AIs you may have installed at once.

## Issue Number
Closes https://github.com/massif-press/compcon/issues/2172 which also closes https://github.com/Eranziel/foundryvtt-lancer/issues/505.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
