### PR TITLE
fix(data): Clean up narrative skills & downtime action decaps

### DIFF
--- a/lib/actions.json
+++ b/lib/actions.json
@@ -414,7 +414,7 @@
   },
   {
     "id": "act_get_a_damn_drink",
-    "name": "Get A Damn Drink",
+    "name": "Get a Damn Drink",
     "activation": "Downtime",
     "terse": "Blow off some steam and generally get into trouble.",
     "detail": "When you GET A DAMN DRINK, you blow off some steam, carouse, and generally get into trouble. You might be trying to make connections, collect gossip, forge a reputation, or even just to forget what happened on the last mission. There’s usually trouble.<br>State your intention and roll:<br>On 9 or less, decide whether you had good time or not; either way, you wake up in a gutter somewhere with only one remaining:<br>• Your dignity.<br>• All of your possessions.<br>• Your memory.<br>On 10–19, gain one as RESERVES and lose one:<br>• A good reputation.<br>• A friend or connection.<br>• A useful item or piece of information.<br>• A convenient opportunity.<br>On 20+, gain two from the 10–19 list as RESERVES and don’t lose anything.<br>You can only make this action where there’s actually a drink to get (e.g., in a town, station, city, or some other populated area), or some other kind of entertainment."
@@ -449,14 +449,14 @@
   },
   {
     "id": "act_power_at_a_cost",
-    "name": "Power At A Cost",
+    "name": "Power at a Cost",
     "activation": "Downtime",
     "terse": "Gain rewards, opportunities, or resources.",
     "detail": "When you seek POWER AT A COST, you’re trying to get your hands on something.<br>Name what you want. You can definitely get it, but depending on the outlandishness of the request, the GM chooses one or two:<br>• It’s going to take a lot more time than you thought.<br>• It’s going to be really damn risky.<br>• You’ll have to have to give something up or leave something behind (e.g., wealth, resources, allies).<br>• You’re going to piss off someone or something important and powerful.<br>• Things are going to go wildly off-plan.<br>• You’ll need more information to proceed safely.<br>• It’s going to fall apart damn soon.<br>• You’ll need more resources, but you know where to find them.<br>• You can get something almost right: a lesser version, or less of it.<br>This is a straightforward way to acquire RESERVES, opportunities, and additional resources. You might want something directly useful for a mission; some‐ thing more abstract, like time, safety, information, allies, or support; something practical, like a base of operations, materials, shelter, or food; or, even something as simple as a damn pack of cigarettes.<br>You can also use POWER AT A COST during missions for similar effects. Other downtime actions generally can’t be used during missions, but your group can adapt them if desired."
   },
   {
     "id": "act_scrounge_and_barter",
-    "name": "Scrounge And Barter",
+    "name": "Scrounge and Barter",
     "activation": "Downtime",
     "terse": "Try and get your hands on some gear or asset.",
     "detail": "When you SCROUNGE AND BARTER, you try to get your hands on some gear or an asset by dredging the scrapyard, chasing down rumors, bartering in the local market, or hunting around.<br>You might want some better pilot gear, a vehicle, narcotics, goods, or other sundries. It needs to be something physical, but doesn’t necessarily have to be on the gear list. If you get it, you can take it on the next mission as RESERVES.<br>Name what you want and roll:<br>On 9 or less, you get what you want, but choose one:<br>• It was stolen, probably from someone who’s looking for it.<br>• It’s degraded, old, filthy, or malfunctioning.<br>• Someone else has it right now and won’t give it up without force or convincing.<br>On 10–19, you get what you want, but choose the price you need to pay:<br>• Time.<br>• Dignity.<br>• Reputation.<br>• Health, comfort, and wellness. On 20+, you get what you’re looking for, no problem."

--- a/lib/glossary.json
+++ b/lib/glossary.json
@@ -120,11 +120,11 @@
     "description": "When characters end their turn in dangerous terrain or move into it for the first time in a round, they must make an ENGINEERING check. On a failure, they take 5 damage – kinetic, energy, explosive, or burn, depending on the hazard. Each character only needs to make one such check per round."
   },
   {
-    "name": "Lifting And Dragging",
+    "name": "Lifting and Dragging",
     "description": "Mechs can drag characters or objects up to twice their SIZE but are SLOWED while doing so. They can also lift characters or objects of equal or lesser SIZE overhead but are IMMOBILIZED while doing so. While dragging or lifting, characters can’t take reactions. The same rules apply to pilots and other characters on foot, but they can’t drag or lift anything above SIZE 1/2.<br><br>While flying, mechs cannot carry characters or objects with a total SIZE larger than SIZE 1/2 -- there's just not enough thrust."
   },
   {
-    "name": "Jumping And Climbing",
+    "name": "Jumping and Climbing",
     "description": "Characters with legs can jump instead of their standard move. They may jump horizontally, moving half their speed in a straight line and ignoring obstructions at ground level that they could jump over (such as pits or gaps), or they may can jump vertically, moving 1 space adjacent and moving up by spaces equivalent to their SIZE. For example, a SIZE 1 mech could jump up to 1 space high, and 1 space over. Characters that jump and end the jump mid air automatically fall at the end of the move (see below).<br><br>Like moving through difficult terrain, characters climb at half their usual SPEED – each space moved is equivalent to moving 2 spaces normally. A successful HULL or AGILITY check might be required to climb particularly difficult surfaces without falling."
   },
   {

--- a/lib/skills.json
+++ b/lib/skills.json
@@ -1,14 +1,14 @@
 [
   {
     "id": "sk_act_unseen_or_unheard",
-    "name": "Act Unseen Or Unheard",
+    "name": "Act Unseen or Unheard",
     "description": "Get somewhere or do something without detection.",
     "detail": "Get somewhere or do something without being detected, but not necessarily with speed. Hide, sneak, or move quietly. Infiltrate a facility while avoiding security, patrols, or cameras. Perform a quick action or maneuver without being seen or heard, such as picking a pocket, unholstering your gun, or cheating at cards. Wear a disguise.",
     "family": "dex"
   },
   {
     "id": "sk_apply_fists_to_faces",
-    "name": "Apply Fists To Faces",
+    "name": "Apply Fists to Faces",
     "description": "Fight in open, brutal unarmed combat.",
     "detail": "Punch someone in the face, or alternately fight in open, brutal unarmed combat, whether it’s a fist fight, martial arts duel, or a huge brawl. This is never subtle, never clean, and probably causes a lot of noise.",
     "family": "str"
@@ -36,7 +36,7 @@
   },
   {
     "id": "sk_get_a_hold_of_something",
-    "name": "Get A Hold Of Something",
+    "name": "Get a Hold of Something",
     "description": "Acquire temporary or permanent allies, assets, or connections through wealth or social influence.",
     "detail": "Acquire useful allies, assets, or connections through wealth or social influence. This could be permanent (buying it or receiving it) or temporary (renting or borrowing help or supplies, etc), and might be harder or easier depending on how much you want to use it. This can’t be used for something that’s normally gated by license level (like mech parts) but could be used for aid, supplies, information, food materials, soldiers, or anything else that has more narrative impact. Typically this is acquired by buying it from a market or requisitioning it from a parent organization.",
     "family": "cha"
@@ -50,14 +50,14 @@
   },
   {
     "id": "sk_hack_or_fix",
-    "name": "Hack Or Fix",
+    "name": "Hack or Fix",
     "description": "Repair a device or faulty system; alternatively, hack it wide open, or totally wreck, disable or sabotage it.",
     "detail": "Repair a device or faulty system. Alternately, hack it wide open, or totally wreck, disable or sabotage it. You can use this for hacking or safeguarding electronic systems, such as electronic door locks, computer systems, omninet webs, or NHP coffins.",
     "family": "int"
   },
   {
     "id": "sk_invent_or_create",
-    "name": "Invent Or Create",
+    "name": "Invent or Create",
     "description": "Invent new devices, tools, or approaches to problems.",
     "detail": "Generally speaking, you need tools and supplies to invent or create something successfully. Use this with many downtime actions to work on projects. You can also use it in the spur of the moment to invent new devices, tools, or approaches to something (improvised explosives, gear, disguises, or some similar).",
     "family": "int"
@@ -71,7 +71,7 @@
   },
   {
     "id": "sk_lead_or_inspire",
-    "name": "Lead Or Inspire",
+    "name": "Lead or Inspire",
     "description": "Give an inspiring speech, or motivate a group of people into action.",
     "detail": "Give an inspiring speech, or motivate a group of people into action. Administer or run an organization efficiently or effectively, such as a company, a ship’s crew, a group of colonists or a mining venture. Effectively command a platoon of soldiers in battle, or (perhaps) an entire army.",
     "family": "cha"
@@ -92,7 +92,7 @@
   },
   {
     "id": "sk_read_a_situation",
-    "name": "Read A Situation",
+    "name": "Read a Situation",
     "description": "Look for subtext, motives, or threats in a situation or person.",
     "detail": "Look for subtext, motive, or threat in a situation or person, often social situations. Use your intuition to learn someone’s motivation, learn who is really in charge, or who is about to do something rash or stupid. Get a gut feeling about a situation or person. Sense if someone is lying to you.",
     "family": "int"
@@ -148,7 +148,7 @@
   },
   {
     "id": "sk_word_on_the_street",
-    "name": "Word On The Street",
+    "name": "Word on the Street",
     "description": "Get gossip, news, or hearsay from the streets, or from a particular social scene.",
     "detail": "Get gossip, news, or hearsay from the streets. What you get depends on what ‘streets’ you are getting word from (high society, low society, hearsay, military chatter, etc). This probably takes a lot less time than investigating something in detail, but the information might be more qualitative or colored by opinion (sometimes that might be useful). You can always learn where the information came from or who to go to next.",
     "family": "cha"

--- a/lib/statuses.json
+++ b/lib/statuses.json
@@ -8,7 +8,7 @@
     "effects": "Characters are in the DANGER ZONE when half or more of their heat is filled in. They’re smoking hot, which enables some attacks, talents, and effects."
   },
   {
-    "name": "Down And Out",
+    "name": "Down and Out",
     "icon": "downandout",
     "type": "Status",
     "terse": "Pilot is unconscious, any additional damage kills",


### PR DESCRIPTION
# Description
Minor PR to cleanup some of the decapitalization of Skills, Downtime Actions, and some miscellaneous rules.

## Issue Number
None

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
