### PR TITLE
fix(package): remove 'module' flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ node_modules/
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+@massif/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@massif/lancer-data",
   "version": "3.1.5",
   "description": "Data for the LANCER TTRPG",
-  "type": "module",
   "main": "index.js",
   "scripts": {
     "build": "node ./scripts/build.js",

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+const fs = require('fs');
 var currentDir = process.cwd();
 var files = fs.readdirSync('./lib');
 let contents = ""


### PR DESCRIPTION
# Description

Removes the `"type": "module"` flag from the `package.json` file. This package's `index.js` is not written to be an ES6 module due to its use of `require`, and as such it encounters errors when imported to other projects.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
