### PR TITLE
feat(data): add suggested skills to all backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,11 @@ C/C will try to calculate the heat cost of item actions based on item tags, but 
 {
   "id": string,
   "name": string,
-  "description": string // v-html
+  "description": string, // v-html
+  "skills"?: string[] // Use ids from skills.json
 }
 ```
+The `skills` field is an optional array of skill IDs from `skills.json`, used to present example skill triggers for a background. Upon selection of a background, if a pilot currently has no skill trigger points assigned, C/C will attempt to auto-populate the pilot with 1 point in each of the example skill triggers.
 
 # CORE Bonuses (core_bonuses.json)
 

--- a/lib/backgrounds.json
+++ b/lib/backgrounds.json
@@ -2,101 +2,221 @@
   {
     "id": "pbg_celebrity",
     "name": "Celebrity",
-    "description": "You were a figure in the public eye. <i>Were you an actor? A singer? An artist? An athlete? A politician? The public face of a corporate or military advertising campaign?</i><br>In your old life, you couldn’t go anywhere without the paparazzi hovering nearby. <i>How are you adjusting to your new life as a pilot? Did you volunteer, or were you conscripted? Can you still practice your art, craft, or profession, or does the rigid military structure make it difficult to pull double-duty?</i>"
+    "description": "You were a figure in the public eye. <i>Were you an actor? A singer? An artist? An athlete? A politician? The public face of a corporate or military advertising campaign?</i><br>In your old life, you couldn’t go anywhere without the paparazzi hovering nearby. <i>How are you adjusting to your new life as a pilot? Did you volunteer, or were you conscripted? Can you still practice your art, craft, or profession, or does the rigid military structure make it difficult to pull double-duty?</i>",
+    "skills": [
+      "sk_charm",
+      "sk_pull_rank",
+      "sk_lead_or_inspire",
+      "sk_threaten"
+    ]
   },
   {
     "id": "pbg_colonist",
     "name": "Colonist",
-    "description": "You were a colonist on the frontier; one of the first generations to be born on a newly settled world. You’re used to the demands of frontier life and well-aware of the precarious position most homesteaders live in. <i>Why did you leave? Were you forced to flee, becoming a refugee? Did you choose to enlist?</i><br>And then there’s the home you left behind: <i>Is the colony still there? Your family? How familiar are you with the luxuries of core worlds? Do you find other cultures difficult to deal with, or are you fascinated by the wealth of humanity’s cultural expression? Do you carry reminders of home, or do you curse its name? Was your colony in a galactic backwater, or is it a fresh colony in a populated, high-traffic area of space? Where is your colony located?</i>"
+    "description": "You were a colonist on the frontier; one of the first generations to be born on a newly settled world. You’re used to the demands of frontier life and well-aware of the precarious position most homesteaders live in. <i>Why did you leave? Were you forced to flee, becoming a refugee? Did you choose to enlist?</i><br>And then there’s the home you left behind: <i>Is the colony still there? Your family? How familiar are you with the luxuries of core worlds? Do you find other cultures difficult to deal with, or are you fascinated by the wealth of humanity’s cultural expression? Do you carry reminders of home, or do you curse its name? Was your colony in a galactic backwater, or is it a fresh colony in a populated, high-traffic area of space? Where is your colony located?</i>",
+    "skills": [
+      "sk_word_on_the_street",
+      "sk_spot",
+      "sk_survive",
+      "sk_patch"
+    ]
   },
   {
     "id": "pbg_criminal",
     "name": "Criminal",
-    "description": "You were a criminal: small-time, master, or something in between. <i>Did you work for corporate clients? A criminal organization? Yourself? Did you mug pedestrians in the dark underbelly of a massive city, or did you slip, unnoticed, into corporate databases to steal data? Did you do it for personal gain, or just to feed your family? How did you find yourself in this life, and how did you become a pilot? Did you operate with a code of honor? Were you loyal to a single family, a small crew, a politician, or an ideology? Did you operate in the shadows, or was your work carried out in the daylight, unafraid of consequences?</i><br>There must be a reason you decided to get out. <i>Was it a bad job, or maybe witness protection? Are your former employers or crew still around? What connections do they have, and how do they feel about you now? What – if anything – haunts you?</i><br>Note: for a more classic “Western” flavor, see the Outlaw Background.<i></i>"
+    "description": "You were a criminal: small-time, master, or something in between. <i>Did you work for corporate clients? A criminal organization? Yourself? Did you mug pedestrians in the dark underbelly of a massive city, or did you slip, unnoticed, into corporate databases to steal data? Did you do it for personal gain, or just to feed your family? How did you find yourself in this life, and how did you become a pilot? Did you operate with a code of honor? Were you loyal to a single family, a small crew, a politician, or an ideology? Did you operate in the shadows, or was your work carried out in the daylight, unafraid of consequences?</i><br>There must be a reason you decided to get out. <i>Was it a bad job, or maybe witness protection? Are your former employers or crew still around? What connections do they have, and how do they feel about you now? What – if anything – haunts you?</i><br>Note: for a more classic “Western” flavor, see the Outlaw Background.<i></i>",
+    "skills": [
+      "sk_threaten",
+      "sk_apply_fists_to_faces",
+      "sk_word_on_the_street",
+      "sk_take_control"
+    ]
   },
   {
     "id": "pbg_far_field_team",
     "name": "Far-Field Team",
-    "description": "You were a member of a Union far-field team (FFT), working on the frontier and the edge of civilization to evaluate strange worlds and planetoids for anomalies, discoveries, and habitability. <i>What have you seen on the wild frontier? How many worlds have you traveled? Were you part of a small team, or a large one? Where is your homeworld?</i><br>Something must drive you to explore: <i>Is it a grail world you seek? An Eden among the stars? Was your interest in the frontier mystical, scientific, based on old-fashioned curiosity, or spurred on by something else? Maybe there was a legend you heard, out there in the dark, that you long to find, or that you’re terrified you might encounter? What secrets – if any – have you encountered on your long-range surveys? Do you remain in contact with your old team members, if they’re still alive?</i><br>As a former (or current) part of an FFT, you're Cosmopolitan: <i>When was “your time”? How separate do you feel from the passage of time?</i>"
+    "description": "You were a member of a Union far-field team (FFT), working on the frontier and the edge of civilization to evaluate strange worlds and planetoids for anomalies, discoveries, and habitability. <i>What have you seen on the wild frontier? How many worlds have you traveled? Were you part of a small team, or a large one? Where is your homeworld?</i><br>Something must drive you to explore: <i>Is it a grail world you seek? An Eden among the stars? Was your interest in the frontier mystical, scientific, based on old-fashioned curiosity, or spurred on by something else? Maybe there was a legend you heard, out there in the dark, that you long to find, or that you’re terrified you might encounter? What secrets – if any – have you encountered on your long-range surveys? Do you remain in contact with your old team members, if they’re still alive?</i><br>As a former (or current) part of an FFT, you're Cosmopolitan: <i>When was “your time”? How separate do you feel from the passage of time?</i>",
+    "skills": [
+      "sk_survive",
+      "sk_investigate",
+      "sk_spot",
+      "sk_charm"
+    ]
   },
   {
     "id": "pbg_hacker",
     "name": "Hacker",
-    "description": "You specialized in information warfare and data espionage, either for your own gain or the benefit of your employers. To you, the omninet – the faster-than-light information web that connects Union worlds – is home. <i>How did you come to this life? Did you grow up plugged into the omninet, or did you come to it late? How well-versed are you in the omninet’s hidden places, tricks, and secrets? How notorious were you before you became a pilot? Do people still whisper your name? Do other hackers remember you, and are you celebrated or cursed among them?</i><br>It wasn’t just the omninet that you hacked, though. <i>How adept are you at manipulating other networks? Can you manipulate discrete systems, genetic code, or some other type of environment, digital or mechanical? What secrets have you gained access to?</i>"
+    "description": "You specialized in information warfare and data espionage, either for your own gain or the benefit of your employers. To you, the omninet – the faster-than-light information web that connects Union worlds – is home. <i>How did you come to this life? Did you grow up plugged into the omninet, or did you come to it late? How well-versed are you in the omninet’s hidden places, tricks, and secrets? How notorious were you before you became a pilot? Do people still whisper your name? Do other hackers remember you, and are you celebrated or cursed among them?</i><br>It wasn’t just the omninet that you hacked, though. <i>How adept are you at manipulating other networks? Can you manipulate discrete systems, genetic code, or some other type of environment, digital or mechanical? What secrets have you gained access to?</i>",
+    "skills": [
+      "sk_act_unseen_or_unheard",
+      "sk_get_a_hold_of_something",
+      "sk_hack_or_fix",
+      "sk_invent_or_create"
+    ]
   },
   {
     "id": "pbg_mechanic",
     "name": "Mechanic",
-    "description": "Grease monkey, wrench, working joe; you were a mechanic prior to becoming a pilot. <i>Did you work in space, swaddled in an EVA rig, patching up damaged starships? Or were you planetside, tuning trucks and haulers in a motor pool? Did you repair battle-torn mechs, dreaming that you might one day pilot your own? Did you own a garage, or did you work for someone? Were you military, corporate, part of a caste, or a union member? How handy are you in the field? Is there a side project you've been working on?</i>"
+    "description": "Grease monkey, wrench, working joe; you were a mechanic prior to becoming a pilot. <i>Did you work in space, swaddled in an EVA rig, patching up damaged starships? Or were you planetside, tuning trucks and haulers in a motor pool? Did you repair battle-torn mechs, dreaming that you might one day pilot your own? Did you own a garage, or did you work for someone? Were you military, corporate, part of a caste, or a union member? How handy are you in the field? Is there a side project you've been working on?</i>",
+    "skills": [
+      "sk_hack_or_fix",
+      "sk_get_somewhere_quickly",
+      "sk_get_a_hold_of_something",
+      "sk_blow_something_up"
+    ]
   },
   {
     "id": "pbg_medic",
     "name": "Medic",
-    "description": "You were a medical specialist in your old life. <i>How did you wind up piloting a mech? What was your specialty? Did you work in research, care, or trauma? Did you love the life and take your duty seriously, or did you see yourself as an organic mechanic?</i><br>You might have worked in a colony or on a core world, in private practice, for a corporation, or on a noble family’s payroll: <i>Did you operate a small frontier practice, or work in a blink station urgent care center, or in a massive hospital campus? Were you a whitecoat or an EMT? Is there a memory that haunts you, or one that gives you comfort?</i>"
+    "description": "You were a medical specialist in your old life. <i>How did you wind up piloting a mech? What was your specialty? Did you work in research, care, or trauma? Did you love the life and take your duty seriously, or did you see yourself as an organic mechanic?</i><br>You might have worked in a colony or on a core world, in private practice, for a corporation, or on a noble family’s payroll: <i>Did you operate a small frontier practice, or work in a blink station urgent care center, or in a massive hospital campus? Were you a whitecoat or an EMT? Is there a memory that haunts you, or one that gives you comfort?</i>",
+    "skills": [
+      "sk_patch",
+      "sk_assault",
+      "sk_read_a_situation",
+      "sk_stay_cool"
+    ]
   },
   {
     "id": "pbg_mercenary",
     "name": "Mercenary",
-    "description": "As a soldier of fortune, you lived by the motto, “have gun, will travel.” You and your kit were available to the highest bidder. <i>Did you work alone or with a crew? Did your company have a ship? Was this when you started piloting mechs of your own? What was your code of honor, if you had one?</i><br>Something pushed you to the mercenary life: <i>Was it the promise of riches? Desire for power? Adventure? Desperation?</i><br>For some reason, you left that life behind: <i>Why? Was there a job that went bad, or one that really was that legendary “one last job”? Are your old company mates still kicking around? Was there a rival company, or other enemies you made? Do you remember that time fondly, or do you never speak of it?</i>"
+    "description": "As a soldier of fortune, you lived by the motto, “have gun, will travel.” You and your kit were available to the highest bidder. <i>Did you work alone or with a crew? Did your company have a ship? Was this when you started piloting mechs of your own? What was your code of honor, if you had one?</i><br>Something pushed you to the mercenary life: <i>Was it the promise of riches? Desire for power? Adventure? Desperation?</i><br>For some reason, you left that life behind: <i>Why? Was there a job that went bad, or one that really was that legendary “one last job”? Are your old company mates still kicking around? Was there a rival company, or other enemies you made? Do you remember that time fondly, or do you never speak of it?</i>",
+    "skills": [
+      "sk_threaten",
+      "sk_blow_something_up",
+      "sk_take_control",
+      "sk_apply_fists_to_faces"
+    ]
   },
   {
     "id": "pbg_nhp_specialist",
     "name": "NHP Specialist",
-    "description": "You were closely involved in the study, creation, or maintenance of a prime non-human person. Nonhuman persons, or NHPs, are complex artificial intelligences. As a prime NHP, the one you were associated with was even more complex than most. <i>Did you interact with that entity like a scientist or engineer, or more like a priest or shaman? Do you have a personal connection to them, after all this time? How do clones of that NHP perceive you? And now that you’re a pilot, how do you feel about non-human intelligence?</i>"
+    "description": "You were closely involved in the study, creation, or maintenance of a prime non-human person. Nonhuman persons, or NHPs, are complex artificial intelligences. As a prime NHP, the one you were associated with was even more complex than most. <i>Did you interact with that entity like a scientist or engineer, or more like a priest or shaman? Do you have a personal connection to them, after all this time? How do clones of that NHP perceive you? And now that you’re a pilot, how do you feel about non-human intelligence?</i>",
+    "skills": [
+      "sk_stay_cool",
+      "sk_read_a_situation",
+      "sk_invent_or_create",
+      "sk_investigate"
+    ]
   },
   {
     "id": "pbg_noble",
     "name": "Noble",
-    "description": "You are a member of your world’s aristocracy, destined from birth to ascend to power. <i>From what authority does this birthright come? A god? An ancestor? An ancient text? A complex annual rotation? How is power passed down from one generation to the next?</i><br>Your noble status came from somewhere: <i>Are you the first in your family to receive a title of nobility, the last of your house, or the scion of a well-established line? Are you the heir, or just a middle child? What’s your relationship with your noble parents?</i><br>Whatever privileges you might have received at home, you found that Union disregards titles in its armed forces; your prior status is just background noise, unless you return home or belong to a group that recognizes nobility. <i>How did you take this change?</i>"
+    "description": "You are a member of your world’s aristocracy, destined from birth to ascend to power. <i>From what authority does this birthright come? A god? An ancestor? An ancient text? A complex annual rotation? How is power passed down from one generation to the next?</i><br>Your noble status came from somewhere: <i>Are you the first in your family to receive a title of nobility, the last of your house, or the scion of a well-established line? Are you the heir, or just a middle child? What’s your relationship with your noble parents?</i><br>Whatever privileges you might have received at home, you found that Union disregards titles in its armed forces; your prior status is just background noise, unless you return home or belong to a group that recognizes nobility. <i>How did you take this change?</i>",
+    "skills": [
+      "sk_pull_rank",
+      "sk_lead_or_inspire",
+      "sk_read_a_situation",
+      "sk_show_off"
+    ]
   },
   {
     "id": "pbg_outlaw",
     "name": "Outlaw",
-    "description": "You came from humble beginnings, born on the edge of cultivated space or beneath the looming towers of core worlds – forgotten until you reached out and took what was owed. Some call you criminal, thief, or outlaw, but you just tell it as it is: if they hadn’t denied you bread, you wouldn’t have had to take it. <i>Were you a brute or a raconteur? A charmer or a monster? Were your actions motivated by ideology, need, desire, or some combination of those three? Who defined you as an “outlaw\", and who saw you as a hero? Is there a bounty on your head?</i>"
+    "description": "You came from humble beginnings, born on the edge of cultivated space or beneath the looming towers of core worlds – forgotten until you reached out and took what was owed. Some call you criminal, thief, or outlaw, but you just tell it as it is: if they hadn’t denied you bread, you wouldn’t have had to take it. <i>Were you a brute or a raconteur? A charmer or a monster? Were your actions motivated by ideology, need, desire, or some combination of those three? Who defined you as an “outlaw\", and who saw you as a hero? Is there a bounty on your head?</i>",
+    "skills": [
+      "sk_show_off",
+      "sk_take_someone_out",
+      "sk_charm",
+      "sk_survive"
+    ]
   },
   {
     "id": "pbg_penal_colonist",
     "name": "Penal Colonist",
-    "description": "A long time ago, you were exiled to a penal colony for a sentence of hard labor. When the Third Committee abolished all penal colonies, your prison-planet was – in theory – “liberated”. Unfortunately, nothing much changed until Union’s relief ships finally arrived. Now free in practice as well as theory, places that had once been off-limits were made open to you: <i>Did you stay for a time? Or did you choose to leave, heading for the stars or trying to find your way back home? Were you guilty of your crimes, or unjustly condemned?</i><br>Penal colonies were harsh, unforgiving environments: <i>Was yours monitored by some authority, or was it relegated to anarchy even before Union's abolition of the system? Was there some kind of rudimentary society there? Did you have friends and enemies there, and did any of them make it off-world? What about your family – did you have one before your sentence? What has become of them, or do you not know?</i>"
+    "description": "A long time ago, you were exiled to a penal colony for a sentence of hard labor. When the Third Committee abolished all penal colonies, your prison-planet was – in theory – “liberated”. Unfortunately, nothing much changed until Union’s relief ships finally arrived. Now free in practice as well as theory, places that had once been off-limits were made open to you: <i>Did you stay for a time? Or did you choose to leave, heading for the stars or trying to find your way back home? Were you guilty of your crimes, or unjustly condemned?</i><br>Penal colonies were harsh, unforgiving environments: <i>Was yours monitored by some authority, or was it relegated to anarchy even before Union's abolition of the system? Was there some kind of rudimentary society there? Did you have friends and enemies there, and did any of them make it off-world? What about your family – did you have one before your sentence? What has become of them, or do you not know?</i>",
+    "skills": [
+      "sk_survive",
+      "sk_apply_fists_to_faces",
+      "sk_word_on_the_street",
+      "sk_spot"
+    ]
   },
   {
     "id": "pbg_priest",
     "name": "Priest",
-    "description": "You were a priest in your old life, either from a large, pan-galactic religion, or a smaller sect. <i>Were you a hermit? Did you live celibate in a monastery? Did you wear simple cloth robes, or majestic vestments? What restrictions were placed upon you by your church? What manner of respect was afforded to you as a person of the cloth, and was it your choice to become one? How did you come to serve as a pilot?</i><br>There are churches everywhere, each unique in their own ways. <i>Were you a member of a prominent religion, or a secretive, outlawed one? Did you preach a Terran faith, born on Cradle and carried for millennia since? Or was yours a Cosmopolitan spirituality, one from the stars and the void of interstellar space? Perhaps you ministered to a small flock of an obscure sect out on the frontier, or in the urban canyons of a core world? Have you kept your faith, or lost it?</i>"
+    "description": "You were a priest in your old life, either from a large, pan-galactic religion, or a smaller sect. <i>Were you a hermit? Did you live celibate in a monastery? Did you wear simple cloth robes, or majestic vestments? What restrictions were placed upon you by your church? What manner of respect was afforded to you as a person of the cloth, and was it your choice to become one? How did you come to serve as a pilot?</i><br>There are churches everywhere, each unique in their own ways. <i>Were you a member of a prominent religion, or a secretive, outlawed one? Did you preach a Terran faith, born on Cradle and carried for millennia since? Or was yours a Cosmopolitan spirituality, one from the stars and the void of interstellar space? Perhaps you ministered to a small flock of an obscure sect out on the frontier, or in the urban canyons of a core world? Have you kept your faith, or lost it?</i>",
+    "skills": [
+      "sk_read_a_situation",
+      "sk_stay_cool",
+      "sk_take_control",
+      "sk_lead_or_inspire"
+    ]
   },
   {
     "id": "pbg_scientist",
     "name": "Scientist",
-    "description": "You were a scientist – private or public, working in the lab or the field. <i>What was your area of expertise, and for how long have you practiced it? Where did you study, and what’s your relationship with that institution? Do you have rivals, and are you well-known or relatively obscure? How did your home society perceive science? How did you become a pilot?</i><br><i>Importantly, did you work with a powerful manufacturer like Harrison Armory, Smith-Shimano, or IPS-N? Or did you delve into the uncanny, working in secret with a small, dedicated HORUS cell? What secrets do you know?</i>"
+    "description": "You were a scientist – private or public, working in the lab or the field. <i>What was your area of expertise, and for how long have you practiced it? Where did you study, and what’s your relationship with that institution? Do you have rivals, and are you well-known or relatively obscure? How did your home society perceive science? How did you become a pilot?</i><br><i>Importantly, did you work with a powerful manufacturer like Harrison Armory, Smith-Shimano, or IPS-N? Or did you delve into the uncanny, working in secret with a small, dedicated HORUS cell? What secrets do you know?</i>",
+    "skills": [
+      "sk_investigate",
+      "sk_invent_or_create",
+      "sk_get_a_hold_of_something",
+      "sk_blow_something_up"
+    ]
   },
   {
     "id": "pbg_soldier",
     "name": "Soldier",
-    "description": "Grunt. GI. Ox. Poilu. Man-at-Arms. You were a soldier of the rank and file, serving in a planetary defense force, local militia, national army, or royal guard. <i>How long did you serve before Union called you up? What kind of specialty did you train for? Have you seen combat before, or are you green? Were you a volunteer, a conscript, or a member of a warrior caste? Is soldiering a proud family, civic, or religious tradition, or a life that you regret? Where are the other soldiers from your old squad, and what is your relationship with them like now?</i>"
+    "description": "Grunt. GI. Ox. Poilu. Man-at-Arms. You were a soldier of the rank and file, serving in a planetary defense force, local militia, national army, or royal guard. <i>How long did you serve before Union called you up? What kind of specialty did you train for? Have you seen combat before, or are you green? Were you a volunteer, a conscript, or a member of a warrior caste? Is soldiering a proud family, civic, or religious tradition, or a life that you regret? Where are the other soldiers from your old squad, and what is your relationship with them like now?</i>",
+    "skills": [
+      "sk_assault",
+      "sk_blow_something_up",
+      "sk_pull_rank",
+      "sk_take_control"
+    ]
   },
   {
     "id": "pbg_spaceborn",
     "name": "Spaceborn",
-    "description": "You grew up on a space station, in tight quarters and a small community, surrounded always by the unforgiving hard vacuum of space. <i>Were resources scarce, or plentiful? Was your station isolated or was it a local (or galactic!) hub? Was it parked in the endless night of deep space, or in orbit above a planet, moon, or another stellar body? Was it entirely manufactured, or was it built into an asteroid or moon?</i><br>No two stations are alike. <i>Did you grow up watching great ships dock and depart – exposed to the thousands of languages and cultures of the galaxy, dreaming of exploration – or did you grow up in dark, rocky halls, ignorant of the galaxy outside? In short, what was your life like, why did you leave, and can you go back?</i>"
+    "description": "You grew up on a space station, in tight quarters and a small community, surrounded always by the unforgiving hard vacuum of space. <i>Were resources scarce, or plentiful? Was your station isolated or was it a local (or galactic!) hub? Was it parked in the endless night of deep space, or in orbit above a planet, moon, or another stellar body? Was it entirely manufactured, or was it built into an asteroid or moon?</i><br>No two stations are alike. <i>Did you grow up watching great ships dock and depart – exposed to the thousands of languages and cultures of the galaxy, dreaming of exploration – or did you grow up in dark, rocky halls, ignorant of the galaxy outside? In short, what was your life like, why did you leave, and can you go back?</i>",
+    "skills": [
+      "sk_survive",
+      "sk_hack_or_fix",
+      "sk_get_somewhere_quickly",
+      "sk_stay_cool"
+    ]
   },
   {
     "id": "pbg_spec_ops",
     "name": "Spec Ops",
-    "description": "You might have been a spy or assassin, working alone, or maybe you were part of an elite unit, operating behind enemy lines with little-to-no support, equipped with the best equipment your commanders trusted you with.<i></i><br>Your missions were long, dangerous, and never publicized. If soldiers are hammers, you were a scalpel. Whatever organization you served, it was spoken only in whispers around military barracks and academies both. <i>What work did you do that no one knows was you or your unit? How close has the galaxy come to all-out war? Where have you operated? How old are you – really? What secrets do you know? Where is the rest of your team?</i>"
+    "description": "You might have been a spy or assassin, working alone, or maybe you were part of an elite unit, operating behind enemy lines with little-to-no support, equipped with the best equipment your commanders trusted you with.<i></i><br>Your missions were long, dangerous, and never publicized. If soldiers are hammers, you were a scalpel. Whatever organization you served, it was spoken only in whispers around military barracks and academies both. <i>What work did you do that no one knows was you or your unit? How close has the galaxy come to all-out war? Where have you operated? How old are you – really? What secrets do you know? Where is the rest of your team?</i>",
+    "skills": [
+      "sk_act_unseen_or_unheard",
+      "sk_take_someone_out",
+      "sk_spot",
+      "sk_stay_cool"
+    ]
   },
   {
     "id": "pbg_super_soldier",
     "name": "Super Soldier",
-    "description": "You are the result of a corporate or state project intended to create better soldiers using biological enhancement, gene therapy, neurological enhancement, or even just extreme conditioning. <i>Were you raised from birth to become what you are, or did you volunteer as an adult for a super-soldier program? Are you one of the countless “super soldiers” to be produced by Harrison Armory’s facsimile-cloning programs? Was the project sanctioned or not? Did it succeed? Have you tested your abilities in the field, or are you unproven and eager to see what you can do?</i><br>Under the Third Committee, fewer programs like the one that created you still operate: <i>Are you happy about that, or do you think it makes Union weak? What is your relationship to your makers? Is there a family that doesn't know you exist? Or are you from a line of mass-pro‐ duced siblings? Were you liberated, did you surrender, or are you still in the service of the organization or entity you were made to serve?</i>"
+    "description": "You are the result of a corporate or state project intended to create better soldiers using biological enhancement, gene therapy, neurological enhancement, or even just extreme conditioning. <i>Were you raised from birth to become what you are, or did you volunteer as an adult for a super-soldier program? Are you one of the countless “super soldiers” to be produced by Harrison Armory’s facsimile-cloning programs? Was the project sanctioned or not? Did it succeed? Have you tested your abilities in the field, or are you unproven and eager to see what you can do?</i><br>Under the Third Committee, fewer programs like the one that created you still operate: <i>Are you happy about that, or do you think it makes Union weak? What is your relationship to your makers? Is there a family that doesn't know you exist? Or are you from a line of mass-pro‐ duced siblings? Were you liberated, did you surrender, or are you still in the service of the organization or entity you were made to serve?</i>",
+    "skills": [
+      "sk_apply_fists_to_faces",
+      "sk_get_somewhere_quickly",
+      "sk_assault",
+      "sk_read_a_situation"
+    ]
   },
   {
     "id": "pbg_starship_pilot",
     "name": "Starship Pilot",
-    "description": "You flew a starship – civilian, corporate, military or otherwise. You may have piloted a freighter, a fighter, a shuttle, or a larger ship. <i>Did you have a regular run, or did you fly anywhere? Were you a member of a crew, or did you have one of your own? What kind of flying did you do and what eventually happened to your ship? Did you stick to low and mid-orbit shuttle runs?</i><br>Being a pilot is as much a lifestyle as it is a profession: <i>What was your callsign, and were you known or obscure? Was there a rival service, pilot, or group of pilots that you had friction with? Have you worked with NHPs or flown in combat? Have you ever seen anything strange out in interstellar space or the total void of blinkspace?</i>"
+    "description": "You flew a starship – civilian, corporate, military or otherwise. You may have piloted a freighter, a fighter, a shuttle, or a larger ship. <i>Did you have a regular run, or did you fly anywhere? Were you a member of a crew, or did you have one of your own? What kind of flying did you do and what eventually happened to your ship? Did you stick to low and mid-orbit shuttle runs?</i><br>Being a pilot is as much a lifestyle as it is a profession: <i>What was your callsign, and were you known or obscure? Was there a rival service, pilot, or group of pilots that you had friction with? Have you worked with NHPs or flown in combat? Have you ever seen anything strange out in interstellar space or the total void of blinkspace?</i>",
+    "skills": [
+      "sk_get_somewhere_quickly",
+      "sk_show_off",
+      "sk_get_a_hold_of_something",
+      "sk_hack_or_fix"
+    ]
   },
   {
     "id": "pbg_worker",
     "name": "Worker",
-    "description": "At the end of the day, empire only functions when labor clocks in. Labor mines the raw materials; labor fashions stone and metal and organic matter into bolts and screws and glue; labor designs the patterns for printers; labor shapes and welds, hammers and builds. Without the labor of trillions, all progress would grind to a halt. <i>Before you set down the wrench and picked up a helm, what kind of work did you do? Did you work in the fields, factories, shipyards, mines, or somewhere else? What was your life like before you began training as a pilot? Why did you leave? Will you return? Was there a project you worked on that you're especially proud of? Do you have an old crew still working on the clock? What world did you call home, and what were the working conditions there?</i>"
+    "description": "At the end of the day, empire only functions when labor clocks in. Labor mines the raw materials; labor fashions stone and metal and organic matter into bolts and screws and glue; labor designs the patterns for printers; labor shapes and welds, hammers and builds. Without the labor of trillions, all progress would grind to a halt. <i>Before you set down the wrench and picked up a helm, what kind of work did you do? Did you work in the fields, factories, shipyards, mines, or somewhere else? What was your life like before you began training as a pilot? Why did you leave? Will you return? Was there a project you worked on that you're especially proud of? Do you have an old crew still working on the clock? What world did you call home, and what were the working conditions there?</i>",
+    "skills": [
+      "sk_word_on_the_street",
+      "sk_stay_cool",
+      "sk_lead_or_inspire",
+      "sk_invent_or_create"
+    ]
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@massif/lancer-data",
-  "version": "3.1.1",
+  "version": "3.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@massif/lancer-data",
-      "version": "3.1.1",
+      "version": "3.1.6",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "zip-lib": "^0.7.3"


### PR DESCRIPTION
# Description
This PR adds an optional `skills` field to all backgrounds, a String Array of skill IDs pulled from the `skills.json`. This data can be used for clearly suggesting and auto-populating skill triggers in CompCon in a potential future update.

## Issue Number
Preparing for implementation of massif-press/compcon#2343

## Type of change
- [x] New feature (non-breaking change which adds functionality)