### PR TITLE
feat(rules): add base Sensors and ST for pilots

### DIFF
--- a/lib/rules.json
+++ b/lib/rules.json
@@ -7,6 +7,8 @@
   "base_pilot_evasion": 10,
   "base_pilot_edef": 10,
   "base_pilot_speed": 4,
+  "base_pilot_sensors": 5,
+  "base_pilot_save_target": 10,
   "minimum_pilot_skills": 4,
   "minimum_mech_skills": 2,
   "minimum_pilot_talents": 3,


### PR DESCRIPTION
# Description

Add base pilot Sensor Range and Save Target rules in case we would like to reference them in the future. Going off of Human NPC statblock, the Search Action for Pilots, and general default Save Target calculations. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
