### PR TITLE
Crack Shot 3: embolden 'steadying your aim' in description

### DIFF
--- a/lib/talents.json
+++ b/lib/talents.json
@@ -242,7 +242,7 @@
       },
       {
         "name": "Watch This",
-        "description": "1/round, when you perform a critical hit with a Rifle while steadying your aim, your target must pass a Hull save or you may choose an additional effect for your attack:<ul><li><b>Headshot:</b> They only have line of sight to adjacent spaces until the end of their next turn.</li><li><b>Leg shot:</b> They become Immobilized until the end of their next turn.</li><li><b>Body shot:</b> They are knocked Prone.</li></ul>",
+          "description": "1/round, when you perform a critical hit with a Rifle while <b>steadying your aim</b>, your target must pass a Hull save or you may choose an additional effect for your attack:<ul><li><b>Headshot:</b> They only have line of sight to adjacent spaces until the end of their next turn.</li><li><b>Leg shot:</b> They become Immobilized until the end of their next turn.</li><li><b>Body shot:</b> They are knocked Prone.</li></ul>",
         "synergies": [
           {
             "locations": ["weapon"],

--- a/lib/talents.json
+++ b/lib/talents.json
@@ -242,7 +242,7 @@
       },
       {
         "name": "Watch This",
-          "description": "1/round, when you perform a critical hit with a Rifle while <b>steadying your aim</b>, your target must pass a Hull save or you may choose an additional effect for your attack:<ul><li><b>Headshot:</b> They only have line of sight to adjacent spaces until the end of their next turn.</li><li><b>Leg shot:</b> They become Immobilized until the end of their next turn.</li><li><b>Body shot:</b> They are knocked Prone.</li></ul>",
+        "description": "1/round, when you perform a critical hit with a Rifle while <b>steadying your aim</b>, your target must pass a Hull save or you may choose an additional effect for your attack:<ul><li><b>Headshot:</b> They only have line of sight to adjacent spaces until the end of their next turn.</li><li><b>Leg shot:</b> They become Immobilized until the end of their next turn.</li><li><b>Body shot:</b> They are knocked Prone.</li></ul>",
         "synergies": [
           {
             "locations": ["weapon"],


### PR DESCRIPTION
# Description

Noticed this wasn't in bold like the rest of the ranks

## Issue Number
N/A

## Type of change

bold tag on "steadying your aim"

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
