### PR TITLE
fix(sitreps): add missing Objective rules for Escort

### DIFF
--- a/lib/sitreps.json
+++ b/lib/sitreps.json
@@ -24,6 +24,7 @@
     "enemyVictory": "The Objective hasn’t been extracted at the end of the eighth round. If there are any PCs remaining on the field when this takes place, they are captured or overrun.",
     "noVictory": "The Objective is destroyed.",
     "deployment": "The PCs deploy first, choosing positions for their characters and the Objective in the Allied Deployment Zone; then, the GM deploys enemy forces in the EDZ.",
+    "objective": "An object or person of Size 1/2–2. The Objective has 10 HP per level of Size, Evasion 10, E-Defense 10, and no Armor. Enemy forces want the Objective and will not willingly damage it. When a character starts their turn adjacent to the Objective, it moves with them when they make their regular move. If the Objective is ever adjacent to two characters of opposing sides, it stops moving and can’t move until it is only adjacent characters from one side. The Objective doesn’t move on its own.",
     "extraction": "While in the Extraction Zone, PCs can extract as a free action at the end of their turn. Extracted PCs are removed from the battlefield. If the Objective is adjacent to a PC when they extract and isn’t contested by any characters from the opposing side, it is safely extracted."
   },
   {


### PR DESCRIPTION
# Description

Add "Objective" field for Escort sitrep (identical to Extraction's `objective`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)