### PR TITLE
fix(systems): fix typo in OSIRIS effect

### DIFF
--- a/lib/systems.json
+++ b/lib/systems.json
@@ -1791,7 +1791,7 @@
     "source": "HORUS",
     "license": "Goblin",
     "license_level": 3,
-    "effect": "Your mech gains the AI tag and and can perform the Hurl Into the Duat QUICK TECH option.",
+    "effect": "Your mech gains the AI tag and can perform the Hurl Into the Duat QUICK TECH option.",
     "actions": [
       {
         "name": "Hurl Into the Duat",


### PR DESCRIPTION
# Description

Fix a "double and" typo in OSIRIS's effect.

## Issue Number

None yet.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
